### PR TITLE
Adds extra information to readme and lowers update_frequency in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ In one of your config files, set up an exometer reporter, and then register
 it to elixometer like this:
 
 ```elixir
+       config(:exometer, report: [reporters: [{:exometer_report_tty, []}]])
        config(:elixometer, reporter: :exometer_report_tty,
        	    env: Mix.env,
        	    metric_prefix: "myapp")
 ```
 Metrics are prepended with the `metric_prefix`, the type of metric and the environment name.
+
+The optional `update_frequency` key of the :elixometer config controls the interval between reports. By default this is set to `1000` ms in the `dev` environment and `20` ms in the `test` environment.
 
 ## Metrics
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,6 +14,6 @@ config :lager, [
   ]]
 
 config :elixometer,  reporter: :exometer_report_tty,
-update_frequency: 50000,
+update_frequency: 1000,
 env: Mix.env,
 metric_prefix: "elixometer"


### PR DESCRIPTION
This patch updates the readme to add additional configuration information that
may help the getting started experience for developers and a small configuration
change to the development config.

Upon implementing elixometer I struggled to figure out why my reporter wasn't being
called, neither a custom reporter nor :exometer_report_tty was working.

After routing around in the source I found that you must register your reporter with
both exometer AND elixometer in order for it to work correctly.

This patch hopes to share that knowledge with the community.