### PR TITLE
Allow counters that don't automatically reset

### DIFF
--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -285,12 +285,17 @@ defmodule Elixometer do
   If the value of the `:reset_seconds` option is greater than zero, the counter will be reset
   automatically at the specified interval.
   """
-  def update_counter(name, delta, opts \\ [reset_seconds: 60]) when is_bitstring(name) do
+  def update_counter(name, delta, opts = [reset_seconds: secs] \\ [reset_seconds: nil]) when is_bitstring(name) and (is_nil(secs) or secs >= 1) do
     monitor = name_to_exometer(:counters, name)
 
     register_metric_once(monitor) do
       :exometer.new(monitor, :counter, [])
-      add_counter(monitor, opts[:reset_seconds] * 1000)
+
+      if is_nil secs do
+        add_counter(monitor, secs)
+      else
+        add_counter(monitor, secs * 1000)
+      end
     end
 
     :exometer.update(monitor, delta)
@@ -413,7 +418,7 @@ defmodule Elixometer do
     Enum.map(config.counters,
       fn({name, millis}) ->
         {:ok, [ms_since_reset: since_reset]} = :exometer.get_value(name, :ms_since_reset)
-        if millis > 0 && since_reset >= millis do
+        if millis && since_reset >= millis do
           :exometer.reset(name)
         end
       end)

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -281,6 +281,9 @@ defmodule Elixometer do
   @doc """
   Updates a counter metric. If the metric doesn't exist, the metric is created
   and the metric is subscribed to the default reporter.
+
+  If the value of the `:reset_seconds` option is greater than zero, the counter will be reset
+  automatically at the specified interval.
   """
   def update_counter(name, delta, opts \\ [reset_seconds: 60]) when is_bitstring(name) do
     monitor = name_to_exometer(:counters, name)
@@ -410,7 +413,7 @@ defmodule Elixometer do
     Enum.map(config.counters,
       fn({name, millis}) ->
         {:ok, [ms_since_reset: since_reset]} = :exometer.get_value(name, :ms_since_reset)
-        if since_reset >= millis do
+        if millis > 0 && since_reset >= millis do
           :exometer.reset(name)
         end
       end)

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Elixometer.Mixfile do
 
   defp deps do
     [
-        {:meck, github: "eproxus/meck", tag: "0.8.2", override: true},
+        {:meck, "~> 0.8.3"},
         {:edown, github: "uwiger/edown", tag: "0.7", override: true},
         {:lager, github: "basho/lager", tag: "2.1.0", override: true},
         {:exometer, github: "pspdfkit-labs/exometer"},

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "goldrush": {:git, "git://github.com/DeadZen/goldrush.git", "71e63212f12c25827e0c1b4198d37d5d018a7fec", [tag: "0.1.6"]},
   "jiffy": {:git, "git://github.com/davisp/jiffy.git", "137d3d94b6ee10001d761d412cbbe7f665680c98", [ref: "0.13.3"]},
   "lager": {:git, "https://github.com/basho/lager.git", "840acab51ebfb731de0137d9c6d41e7db4a12793", [tag: "2.1.0"]},
-  "meck": {:git, "https://github.com/eproxus/meck.git", "dde759050eff19a1a80fd854d7375174b191665d", [tag: "0.8.2"]},
+  "meck": {:hex, :meck, "0.8.3"},
   "netlink": {:git, "https://github.com/Feuerlabs/netlink.git", "d6e7188e907015166afba09fbf2f433b9fe08360", [ref: "d6e7188e"]},
   "parse_trans": {:git, "git://github.com/uwiger/parse_trans.git", "82cc00264aa1bad8fc5c0739b7541feb4a843432", [tag: "2.9"]},
   "rabbit_common": {:git, "git://github.com/jbrisbin/rabbit_common.git", "9c1965273032ffb79ec0ff80b250e5d0b4608aa7", [tag: "rabbitmq-3.3.5"]},

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -131,6 +131,23 @@ defmodule ElixometerTest do
     assert val == 0
   end
 
+  test "a counter does not reset itself if reset_seconds is < 1" do
+    update_counter("no_reset", 1, reset_seconds: 0)
+
+    expected_name = [:elixometer, :test, :counters, :no_reset]
+    {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
+    assert val == 1
+
+    :timer.sleep(500)
+    {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
+    assert val == 1
+
+    :timer.sleep(800)
+
+    {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
+    assert val == 1
+  end
+
   test "a timer registers its name" do
     timed("register", do: 1 + 1)
 

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -131,8 +131,8 @@ defmodule ElixometerTest do
     assert val == 0
   end
 
-  test "a counter does not reset itself if reset_seconds is < 1" do
-    update_counter("no_reset", 1, reset_seconds: 0)
+  test "a counter does not reset itself if reset_seconds is nil" do
+    update_counter("no_reset", 1, reset_seconds: nil)
 
     expected_name = [:elixometer, :test, :counters, :no_reset]
     {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
@@ -146,6 +146,10 @@ defmodule ElixometerTest do
 
     {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
     assert val == 1
+  end
+
+  test "a counter fails to register if reset_seconds is < 1" do
+    assert_raise FunctionClauseError, fn -> update_counter("will_fail", 1, reset_seconds: 0) end
   end
 
   test "a timer registers its name" do


### PR DESCRIPTION
My use case is tracking quota usage for a third party API, where the usage meter resets daily. I'd planned on resetting my quota counter at the appropriate time with [Quantum](https://github.com/c-rack/quantum-elixir), but soon realized that counter values already reset every 60 seconds by default. So, I made it possible to disable the auto-reset. The change should be non-breaking.

I am curious, though: why is auto-reset the default? AFAICT, Exometer doesn't do this.