### PR TITLE
Add various project info. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ otp_release:
 sudo: false
 install: true
 script:
-  - mix deps.get && mix test
+  - mix deps.get && mix test --trace
 cache:
   directories:
   - $HOME/.mix/archives

--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,10 @@ defmodule Elixometer.Mixfile do
     [app: :elixometer,
      version: "1.0.0",
      elixir: "~> 1.0",
+     description: description,
+     source_url: project_url,
+     homepage_url: project_url,
+     package: package,
      deps: deps]
   end
 
@@ -31,5 +35,25 @@ defmodule Elixometer.Mixfile do
         {:exometer, github: "pspdfkit-labs/exometer"},
         {:netlink, github: "Feuerlabs/netlink", ref: "d6e7188e", override: true},
     ]
+  end
+
+  defp description do
+    """
+    Elixometer is a light wrapper around exometer that defines and subscribes metrics automatically
+to the configured reporter.
+    """
+  end
+
+  defp project_url do
+    """
+    https://github.com/pinterest/elixometer
+    """
+  end
+
+  defp package do
+    [files: ["config", "lib", "mix.exs", "README.md", "LICENSE"],
+     maintainers: ["Jon Parise", "Steve Cohen"],
+     licenses: ["Apache 2.0"],
+     links: %{"GitHub" => project_url}]
   end
 end


### PR DESCRIPTION
* add various project info in mix (they will show up if do a hex.build)
  Lots of Elixir projects publish using hex. Hex needs credentials so up to you.
  http://trivelop.de/2014/10/17/continous-docs-in-elixir-with-hex-and-travis/
* don't accidentally check in your credential to github or display in travisci build log if you choose to do so
* show details on test run esp. for travisci