### PR TITLE
Notice that the most repo travisci build errored out.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ otp_release:
   - 18.1
 sudo: false
 install: true
+before_script:
+  - mix local.hex --force
 script:
   - mix deps.get && mix test
 cache:


### PR DESCRIPTION
* fix prompting for hex installation (force hex installed locally beforehand)
* repo errored out build status:
  https://travis-ci.org/pinterest/elixometer/builds/100247896