### PR TITLE
Fix compiler warning of unused variable

### DIFF
--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -285,7 +285,7 @@ defmodule Elixometer do
   If the value of the `:reset_seconds` option is greater than zero, the counter will be reset
   automatically at the specified interval.
   """
-  def update_counter(name, delta, opts = [reset_seconds: secs] \\ [reset_seconds: nil]) when is_bitstring(name) and (is_nil(secs) or secs >= 1) do
+  def update_counter(name, delta, [reset_seconds: secs] \\ [reset_seconds: nil]) when is_bitstring(name) and (is_nil(secs) or secs >= 1) do
     monitor = name_to_exometer(:counters, name)
 
     register_metric_once(monitor) do


### PR DESCRIPTION
Per build status:
https://travis-ci.org/pinterest/elixometer/builds/100271457
Compiled lib/supervisor.ex
lib/elixometer.ex:288: warning: variable opts is unused
Compiled lib/elixometer.ex
Generated elixometer app
