### PR TITLE
Fix coverall.io badge url; add test execution details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install: true
 before_script:
   - mix local.hex --force
 script:
-  - MIX_ENV=test mix do deps.get, test
+  - MIX_ENV=test mix do deps.get, test --trace
 after_script:
   - MIX_ENV=test mix coveralls.travis
 cache:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Elixometer
 ==========
 
 [![Build Status](https://travis-ci.org/pinterest/elixometer.svg?branch=master)](https://travis-ci.org/pinterest/elixometer)
-[![Coverage Status](https://coveralls.io/repos/pinterest/elixometer/badge.svg?branch=&service=github)](https://coveralls.io/github/pinterest/elixometer?branch=)
+[![Coverage Status](https://coveralls.io/repos/pinterest/elixometer/badge.svg?branch=&service=github)](https://coveralls.io/github/pinterest/elixometer?branch=master)
 
 A light wrapper around exometer.
 


### PR DESCRIPTION
* Fix code coverage badge url
* Add test execution detail show up on build. It is hard to tell which test failed