### PR TITLE
Removed exometer as a dependency

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :exometer, report: [reporters: []]
+config :exometer_core, report: [reporters: []]
 
 config :lager, [
   log_root: 'log',

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config(:exometer, report: [reporters: [{Elixometer.TestReporter, []}]])
+config(:exometer_core, report: [reporters: [{Elixometer.TestReporter, []}]])
 
 config(:elixometer, update_frequency: 20,
        reporter: Elixometer.TestReporter,

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Elixometer.Mixfile do
 
   def application do
      [mod: {Elixometer.App, []},
-      applications: [:logger, :exometer],
+      applications: [:logger, :exometer_core],
       env: default_config(Mix.env)
      ]
   end
@@ -32,11 +32,10 @@ defmodule Elixometer.Mixfile do
 
   defp deps do
     [
-        {:meck, "~> 0.8.3"},
+        {:meck, "~> 0.8.3", only: :test},
         {:edown, github: "uwiger/edown", tag: "0.7", override: true},
         {:lager, github: "basho/lager", tag: "2.1.0", override: true},
-        {:exometer, github: "pspdfkit-labs/exometer"},
-        {:netlink, github: "Feuerlabs/netlink", ref: "d6e7188e", override: true},
+        {:exometer_core, git: "git://github.com/PSPDFKit-labs/exometer_core.git", branch: "master"},
         {:excoveralls, github: "parroty/excoveralls", tag: "v0.4.3", override: true, only: :test}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "exjsx": {:hex, :exjsx, "3.2.0"},
   "exometer": {:git, "https://github.com/pspdfkit-labs/exometer.git", "fc367682a809ccd463a907e6e00e52d6d354c83f", []},
   "exometer_collectd": {:git, "git://github.com/Feuerlabs/exometer_collectd.git", "e71e8e5f43e04ee3e4727e2a32f4952073a4530e", [tag: "1.0"]},
-  "exometer_core": {:git, "git://github.com/PSPDFKit-labs/exometer_core.git", "ccc18cf0328692756fd9b837a88823cf979da8e1", [branch: "master"]},
+  "exometer_core": {:git, "https://github.com/pspdfkit-labs/exometer_core.git", "ccc18cf0328692756fd9b837a88823cf979da8e1", []},
   "folsom": {:git, "git://github.com/boundary/folsom", "38e2cce7c64ce1f0a3a918d90394cfc0a940b1ba", [tag: "0.8.2"]},
   "goldrush": {:git, "git://github.com/DeadZen/goldrush.git", "71e63212f12c25827e0c1b4198d37d5d018a7fec", [tag: "0.1.6"]},
   "hackney": {:hex, :hackney, "1.4.8"},


### PR DESCRIPTION
The community doesn't like having exometer as a dependency since most of
the popular reporters are inside of exometer_core anyway. I removed it
and cleaned up some of the other dependencies as well.

Addresses #19 

@jparise 