### PR TITLE
Fix upgrade excoveralls to 0.4.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Elixometer.Mixfile do
         {:edown, github: "uwiger/edown", tag: "0.7", override: true},
         {:lager, github: "basho/lager", tag: "2.1.0", override: true},
         {:exometer_core, git: "git://github.com/PSPDFKit-labs/exometer_core.git", branch: "master"},
-        {:excoveralls, github: "parroty/excoveralls", tag: "v0.4.3", override: true, only: :test}
+        {:excoveralls, github: "parroty/excoveralls", tag: "v0.4.5", override: true, only: :test}
     ]
   end
 


### PR DESCRIPTION
Upgrade all elixir project to use same version as in elixir-thrift:
reference
https://github.com/pinterest/elixir-thrift/commit/12407035ff5fe480ba957c1379d4478ef1099fb5