### PR TITLE
Fix start with :lager instead of :logger

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule Elixometer.Mixfile do
 
   def application do
      [mod: {Elixometer.App, []},
-      applications: [:logger, :exometer_core],
+      applications: [:lager, :exometer_core],
+      erl_opts: [parse_transform: "lager_transform"],
       env: default_config(Mix.env)
      ]
   end


### PR DESCRIPTION
When application is started, it error on :logger.
exometer and other dependency projects uses :lager. 

PR is to start :lager right from the start instead of :logger.

Error message

2015-12-31 14:05:00 =SUPERVISOR REPORT====
     Supervisor: {local,'Elixir.Logger.Supervisor'}
     Context:    child_terminated
     Reason:     normal
     Offender:   [{pid,<0.183.0>},{id,'Elixir.Logger.ErrorHandler'},{mfargs,{'Elixir.Logger.Watcher',watcher,[error_logger,'Elixir.Logger.ErrorHandler',{true,false,500},link]}},{restart_type,permanent},{shutdown,5000},{child_type,worker}]
