### PR TITLE
Update README to configure `exometer_core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In one of your config files, set up an exometer reporter, and then register
 it to elixometer like this:
 
 ```elixir
-       config(:exometer, report: [reporters: [{:exometer_report_tty, []}]])
+       config(:exometer_core, report: [reporters: [{:exometer_report_tty, []}]])
        config(:elixometer, reporter: :exometer_report_tty,
        	    env: Mix.env,
        	    metric_prefix: "myapp")


### PR DESCRIPTION
Using the current example in an application causes the following error:

> You have configured application :exometer in your configuration
> file but the application is not available.

I think this is because #20 updated elixometer to depend on
exometer_core instead of exometer, but did not update the README to
configure exometer_core.