### PR TITLE
Expand testing matrix to include 1.2.6 and 1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: elixir
 elixir:
-  - 1.1.1
+  - 1.2.6
+  - 1.3.2
 otp_release:
-  - 18.1
+  - 18.3
 sudo: false
 install: true
 before_script:
   - mix local.hex --force
+  - mix local.rebar --force
 script:
   - MIX_ENV=test mix do deps.get, test --trace
 after_script:


### PR DESCRIPTION
Also include OTP 18.3, and drop 1.1.1 and OTP 18.1.