### PR TITLE
Adds configurable 'extra' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ In case a reporter allows for extra configuration options on subscribe, you can 
 ```elixir
        config(:elixometer,
        	    ...
-       	    extra: [{:tag, :value1}])
+       	    subscribe_options: [{:tag, :value1}])
 ```

--- a/README.md
+++ b/README.md
@@ -99,3 +99,11 @@ By default, Elixometer only includes the `exometer_core` package. However, some 
     ]
   end
 ```
+
+In case a reporter allows for extra configuration options on subscribe, you can configure them in your `elixometer` config like so:
+
+```elixir
+       config(:elixometer,
+       	    ...
+       	    extra: [{:tag, :value1}])
+```

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -345,12 +345,12 @@ defmodule Elixometer do
       cfg = Application.get_all_env(:elixometer)
       reporter = cfg[:reporter]
       interval = cfg[:update_frequency]
-      extra = cfg[:extra] || true
+      subscribe_options = cfg[:subscribe_options] || true
 
       if reporter do
         :exometer.info(metric_name)
         |> Keyword.get(:datapoints)
-        |> Enum.map(&(:exometer_report.subscribe(reporter, metric_name, &1, interval, extra)))
+        |> Enum.map(&(:exometer_report.subscribe(reporter, metric_name, &1, interval, subscribe_options)))
       end
       :ets.insert(@elixometer_table, {{:subscriptions, metric_name}, true})
     end

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -345,11 +345,12 @@ defmodule Elixometer do
       cfg = Application.get_all_env(:elixometer)
       reporter = cfg[:reporter]
       interval = cfg[:update_frequency]
+      extra = cfg[:extra] || true
 
       if reporter do
         :exometer.info(metric_name)
         |> Keyword.get(:datapoints)
-        |> Enum.map(&(:exometer_report.subscribe(reporter, metric_name, &1, interval)))
+        |> Enum.map(&(:exometer_report.subscribe(reporter, metric_name, &1, interval, extra)))
       end
       :ets.insert(@elixometer_table, {{:subscriptions, metric_name}, true})
     end

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -268,11 +268,11 @@ defmodule ElixometerTest do
   end
 
   test "a subscription that has additional subscription options" do
-    Application.put_env(:elixometer, :subscribe_options, [{:some_option, 42}])
+    Application.put_env(:elixometer, :subscribe_options, [some_option: 42])
 
     update_counter("subscribe_options", 1)
 
     assert subscription_exists "elixometer.test.counters.subscribe_options"
-    assert [{:some_option, 42}] = Reporter.options_for("elixometer.test.counters.subscribe_options")
+    assert [some_option: 42] = Reporter.options_for("elixometer.test.counters.subscribe_options")
   end
 end

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -267,4 +267,12 @@ defmodule ElixometerTest do
     assert {:error, :not_found} == get_metric_value("elixometer.test.bad.bad")
   end
 
+  test "a subscription that has additional subscription options" do
+    Application.put_env(:elixometer, :subscribe_options, [{:some_option, 42}])
+
+    update_counter("subscribe_options", 1)
+
+    assert subscription_exists "elixometer.test.counters.subscribe_options"
+    assert [{:some_option, 42}] = Reporter.options_for("elixometer.test.counters.subscribe_options")
+  end
 end


### PR DESCRIPTION
E.g. for InfluxDB adapter you can pass in tags via these extra fields.

Would be even more useful if it could be done optionally in every wrapper function, but I wasn't sure how to accomplish that.