### PR TITLE
Use a list as a fallback for `:subscribe_options`

### DIFF
--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -345,7 +345,7 @@ defmodule Elixometer do
       cfg = Application.get_all_env(:elixometer)
       reporter = cfg[:reporter]
       interval = cfg[:update_frequency]
-      subscribe_options = cfg[:subscribe_options] || true
+      subscribe_options = cfg[:subscribe_options] || []
 
       if reporter do
         :exometer.info(metric_name)


### PR DESCRIPTION
The `:subscribe_options` configuration entry is documented
as a list, but the fallback value is `true`.  This causes
problems with, e.g., the InfluxDB reporter, which expects
extra subscription options to be a list or `undefined`.