### PR TITLE
Broaden support for pre-computing metric names

### DIFF
--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,4 +1,9 @@
 defmodule Elixometer.Utils do
+  # Name may already have been converted elsewhere.
+  def name_to_exometer(_metric_type, name) when is_list(name) do
+    name
+  end
+
   def name_to_exometer(metric_type, name) when is_bitstring(name) do
     config = Application.get_all_env(:elixometer)
     prefix = config[:metric_prefix] || "elixometer"

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -250,6 +250,14 @@ defmodule ElixometerTest do
     assert subscription_exists "elixometer.test.spirals.subscription"
   end
 
+  test "name can be precomputed" do
+    name = Elixometer.Utils.name_to_exometer(:spirals, "precomputed_counter")
+    update_spiral(name, 123)
+    wait_for_messages
+
+    assert get_metric_value("elixometer.test.spirals.precomputed_counter", :one) == {:ok, 123}
+  end
+
   test "getting a value with no arguments" do
     update_gauge "value", 100
 


### PR DESCRIPTION
Profiling showed a significant amount of time being spent in
Utils.name_to_exometer and to_atom_list. One solution is to convert static
metric names to lists ahead of time, or otherwise manually assembling the
desired list form of the metric. Updater.timer supports this pattern by
avoiding a double conversion, but counter/etc do not. This change should
add support to all metric types.

There is a bit of redundancy now in that Updater.timer still does its check. I
haven't removed it because I'm not sure if there was some reason we always
wanted timer metric names converted in the calling process, rather than in the
registered Updater process.