### PR TITLE
Added parentheses to get rid of Elixir 1.4 warnings.

### DIFF
--- a/lib/updater.ex
+++ b/lib/updater.ex
@@ -10,9 +10,9 @@ defmodule Elixometer.Updater do
   use GenServer
 
   def init([]) do
-    {:ok, pobox} = :pobox.start_link(self, @max_messages, :queue)
+    {:ok, pobox} = :pobox.start_link(self(), @max_messages, :queue)
     Process.register(pobox, :elixometer_pobox)
-    activate_pobox
+    activate_pobox()
     {:ok, nil}
   end
 
@@ -49,7 +49,7 @@ defmodule Elixometer.Updater do
     messages
     |> Enum.each(&do_update/1)
 
-    activate_pobox
+    activate_pobox()
 
     {:noreply, state}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,11 @@ defmodule Elixometer.Mixfile do
     [app: :elixometer,
      version: "1.2.1",
      elixir: ">= 1.0.0",
-     description: description,
-     source_url: project_url,
-     homepage_url: project_url,
-     package: package,
-     deps: deps,
+     description: description(),
+     source_url: project_url(),
+     homepage_url: project_url(),
+     package: package(),
+     deps: deps(),
      test_coverage: [tool: ExCoveralls],
      preferred_cli_env: ["coveralls": :test,
                          "coveralls.detail": :test,
@@ -62,7 +62,7 @@ to   the configured reporter.
      [files: ["config", "lib", "mix.exs", "mix.lock", "README.md", "LICENSE"],
       maintainers: ["Jon Parise", "Steve Cohen"],
       licenses: ["Apache 2.0"],
-      links: %{"GitHub" => project_url}
+      links: %{"GitHub" => project_url()}
      ]
   end
 


### PR DESCRIPTION
Elixir 1.4 deprecated bare words, so this removes a bunch of the new compiler warnings. 

```
❯ elixir --version
Erlang/OTP 19 [erts-8.2] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.4.0

❯ mix compile --force --warnings-as-errors
Compiling 4 files (.ex)
Generated elixometer app
```