### PR TITLE
Test our oldest and newest Elixir version pairs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: elixir
-elixir:
-  - 1.3.2
-otp_release:
-  - 19.0
+elixir: 1.0.0
+otp_release: 18.2
+matrix:
+  include:
+    - elixir: 1.4.0
+      otp_release: 19.2
 sudo: false
-install: true
-before_script:
-  - mix local.rebar --force
-  - mix local.hex --force
-script:
-  - MIX_ENV=test mix do deps.get, test --trace
 after_script:
   - MIX_ENV=test mix coveralls.travis
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir: 1.0.0
-otp_release: 18.2
+otp_release: 17.4
 matrix:
   include:
     - elixir: 1.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: elixir
-elixir: 1.2.6
+elixir: 1.3.0
 otp_release: 18.2
 matrix:
   include:
-    - elixir: 1.4.0
-      otp_release: 19.2
-install:
-  - mix local.rebar --force
-  - mix local.hex --force
-  - mix deps.get
+  - elixir: 1.4.0
+    otp_release: 19.2
 after_script:
   - MIX_ENV=test mix coveralls.travis
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
-elixir: 1.3.4
+elixir: 1.2.6
 otp_release: 18.2
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
-elixir: 1.2.0
-otp_release: 19.2
+elixir: 1.3.4
+otp_release: 18.2
 matrix:
   include:
     - elixir: 1.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
-elixir: 1.0.0
-otp_release: 17.4
+elixir: 1.2.0
+otp_release: 18.2
 matrix:
   include:
     - elixir: 1.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ matrix:
   include:
     - elixir: 1.4.0
       otp_release: 19.2
-sudo: false
+install:
+  - mix local.rebar --force
+  - mix local.hex --force
+  - mix deps.get
 after_script:
   - MIX_ENV=test mix coveralls.travis
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir: 1.2.0
-otp_release: 18.2
+otp_release: 19.2
 matrix:
   include:
     - elixir: 1.4.0

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Elixometer.Mixfile do
   def project do
     [app: :elixometer,
      version: "1.2.1",
-     elixir: ">= 1.2.0",
+     elixir: ">= 1.3.0",
      description: description(),
      source_url: project_url(),
      homepage_url: project_url(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Elixometer.Mixfile do
   def project do
     [app: :elixometer,
      version: "1.2.1",
-     elixir: ">= 1.0.0",
+     elixir: ">= 1.2",
      description: description(),
      source_url: project_url(),
      homepage_url: project_url(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Elixometer.Mixfile do
   def project do
     [app: :elixometer,
      version: "1.2.1",
-     elixir: ">= 1.2",
+     elixir: ">= 1.2.0",
      description: description(),
      source_url: project_url(),
      homepage_url: project_url(),


### PR DESCRIPTION
This revises the build matrix so that we test the oldest supported
Elixir version (now 132.0) as well as the newest (currently 1.4.0).

Note that increase in minimum version to Elixir 1.3.0. Due to previous
changes related to our lager version override, we can no longer support
Elixir 1.0.0.

This also removes some unnecessary setup steps; all of the removed
things already happen by default.