### PR TITLE
Add parens to ambiguous function calls

### DIFF
--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -37,7 +37,7 @@ defmodule ElixometerTest do
     end
 
     def public_secret_timed do
-      secret_timed
+      secret_timed()
     end
 
     @timed(key: "defp_timed")
@@ -71,7 +71,7 @@ defmodule ElixometerTest do
   end
 
   def metric_exists(metric_name) when is_list(metric_name) do
-    wait_for_messages
+    wait_for_messages()
     metric_name in Reporter.metric_names
   end
 
@@ -80,7 +80,7 @@ defmodule ElixometerTest do
   end
 
   def subscription_exists(metric_name) when is_list(metric_name) do
-    wait_for_messages
+    wait_for_messages()
     metric_name in Reporter.subscriptions
   end
 
@@ -137,7 +137,7 @@ defmodule ElixometerTest do
   test "a counter resets itself after its time has elapsed" do
     update_counter("reset", 1, reset_seconds: 1)
 
-    wait_for_messages
+    wait_for_messages()
 
     expected_name = [:elixometer, :test, :counters, :reset]
     {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
@@ -156,7 +156,7 @@ defmodule ElixometerTest do
   test "a counter does not reset itself if reset_seconds is nil" do
     update_counter("no_reset", 1, reset_seconds: nil)
 
-    wait_for_messages
+    wait_for_messages()
 
     expected_name = [:elixometer, :test, :counters, :no_reset]
     {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
@@ -253,7 +253,7 @@ defmodule ElixometerTest do
   test "name can be precomputed" do
     name = Elixometer.Utils.name_to_exometer(:spirals, "precomputed_counter")
     update_spiral(name, 123)
-    wait_for_messages
+    wait_for_messages()
 
     assert get_metric_value("elixometer.test.spirals.precomputed_counter", :one) == {:ok, 123}
   end
@@ -267,7 +267,7 @@ defmodule ElixometerTest do
   test "getting a specific metric" do
     update_gauge "value_2", 23
 
-    wait_for_messages
+    wait_for_messages()
 
     assert {:ok, 23} == get_metric_value("elixometer.test.gauges.value_2", :value)
   end
@@ -279,7 +279,7 @@ defmodule ElixometerTest do
   test "getting a datapoint that doesn't exist" do
     update_gauge "no_datapoint", 22
 
-    wait_for_messages
+    wait_for_messages()
 
     assert {:ok, :undefined} == get_metric_value("elixometer.test.gauges.no_datapoint", :bad_datapoint)
 


### PR DESCRIPTION
This addresses Elixir 1.4 warnings.