### PR TITLE
Add support for all Elixir time units

### DIFF
--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -241,9 +241,8 @@ defmodule Elixometer do
   subscribed to the default reporter.
 
   The time units default to *microseconds*, but you can also pass in any of
-  the units in [`System.time_unit.t`](https://hexdocs.pm/elixir/System.html#t:time_unit/0),
-  with the exception of `pos_integer`. This includes `:second`, `:millisecond`,
-  `:microsecond`, and `:nanosecond`.
+  the units in `t:System.time_unit/0`, with the exception of `pos_integer`.
+  This includes `:second`, `:millisecond`, `:microsecond`, and `:nanosecond`.
 
   Note that nanoseconds are provided for convenience, but Erlang does not
   actually provide this much granularity.

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -70,7 +70,7 @@ defmodule Elixometer do
 
   defmodule Timer do
     @moduledoc false
-    defstruct method_name: nil, key: nil, units: :micros, args: nil, guards: nil, body: nil
+    defstruct method_name: nil, key: nil, units: :microsecond, args: nil, guards: nil, body: nil
   end
 
   @elixometer_table :elixometer
@@ -109,7 +109,7 @@ defmodule Elixometer do
               other -> other
             end
 
-      units = timer_info[:units] || :micros
+      units = timer_info[:units] || :microsecond
       Module.put_attribute(mod, :elixometer_timers,
                            %Timer{method_name: name,
                                   args: args,
@@ -240,10 +240,15 @@ defmodule Elixometer do
   Updates a timer metric. If the metric doesn't exist, it will be created and
   subscribed to the default reporter.
 
-  The time units default to *microseconds*, but you can pass in a unit of
-  `:millis` and the value will be converted.
+  The time units default to *microseconds*, but you can also pass in any of
+  the units in [`System.time_unit.t`](https://hexdocs.pm/elixir/System.html#t:time_unit/0),
+  with the exception of `pos_integer`. This includes `:second`, `:millisecond`,
+  `:microsecond`, and `:nanosecond`.
+
+  Note that nanoseconds are provided for convenience, but Erlang does not
+  actually provide this much granularity.
   """
-  defmacro timed(name, units \\ :micros, do: block) do
+  defmacro timed(name, units \\ :microsecond, do: block) do
     converted_name = Elixometer.Utils.name_to_exometer(:timers, name)
 
     quote do

--- a/lib/updater.ex
+++ b/lib/updater.ex
@@ -102,10 +102,13 @@ defmodule Elixometer.Updater do
       :exometer.new(name, :histogram, [])
     end)
 
-    elapsed_time = case units do
-                     :micros -> elapsed_us
-                     :millis -> elapsed_us / 1000
-                   end
+    elapsed_time =
+      cond do
+        units in [:nanosecond, :nanoseconds] -> elapsed_us * 1000
+        units in [:micros, :microsecond, :microseconds] -> elapsed_us
+        units in [:millis, :millisecond, :milliseconds] -> div(elapsed_us, 1000)
+        units in [:second, :seconds] -> div(elapsed_us, 1_000_000)
+      end
 
     :exometer.update(name, elapsed_time)
   end

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -188,20 +188,36 @@ defmodule ElixometerTest do
     assert subscription_exists "elixometer.test.timers.subscription"
   end
 
-  test "a timer can time in milliseconds" do
-    timed("millis", :millis, do: :timer.sleep(1))
+  test "a timer can time in seconds" do
+    timed("second", :second, do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.millis"
-    [{99, ms}] = Reporter.value_for("elixometer.test.timers.millis", 99)
+    assert subscription_exists "elixometer.test.timers.second"
+    [{99, s}] = Reporter.value_for("elixometer.test.timers.second", 99)
+    assert s <= 1
+  end
+
+  test "a timer can time in milliseconds" do
+    timed("millisecond", :millisecond, do: :timer.sleep(1))
+
+    assert subscription_exists "elixometer.test.timers.millisecond"
+    [{99, ms}] = Reporter.value_for("elixometer.test.timers.millisecond", 99)
     assert ms <= 10
   end
 
   test "a timer times in microseconds by default" do
-    timed("micros", do: :timer.sleep(1))
+    timed("microsecond", do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.micros"
-    [{_data_point, value}] = Reporter.value_for("elixometer.test.timers.micros", 99)
+    assert subscription_exists "elixometer.test.timers.microsecond"
+    [{_data_point, value}] = Reporter.value_for("elixometer.test.timers.microsecond", 99)
     assert value > 1000
+  end
+
+  test "a timer can time in nanoseconds" do
+    timed("nanosecond", :nanosecond, do: :timer.sleep(1))
+
+    assert subscription_exists "elixometer.test.timers.nanosecond"
+    [{99, ns}] = Reporter.value_for("elixometer.test.timers.nanosecond", 99)
+    assert ns > 1_000_000
   end
 
   test "a timer defined in the module's declaration" do


### PR DESCRIPTION
To maintain consistency with the Elixir standard library, Elixometer should support all the same time units. These can be viewed at https://hexdocs.pm/elixir/System.html#t:time_unit/0.

I left in support for `:micros` and `:millis` so that this is not a breaking change, but I also made `:microsecond` the default.