### PR TITLE
Do not generate atoms / custom metrics formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,29 @@ Metrics are prepended with the `metric_prefix`, the type of metric and the envir
 
 The optional `update_frequency` key of the :elixometer config controls the interval between reports. By default this is set to `1000` ms in the `dev` environment and `20` ms in the `test` environment.
 
+By default, metrics are formatted using `Elixometer.Utils.name_to_exometer/2`.
+This function takes care of composing metric names with prefix, environment and
+the metric type (e.g. `myapp_prefix.dev.timers.request_time`).
+
+This behaviour can be overridden with a custom formatter function, by adding the
+following configuration entry:
+
+```elixir
+  config :elixometer, Elixometer.Updater,
+    formatter: &MyApp.Metrics.my_custom_formatter/2
+```
+
+Elixometer uses [`pobox`](https://github.com/ferd/pobox) to prevent overload.
+A maximum size of message buffer, defaulting to 1000, can be configured with:
+
+```elixir
+config :elixometer, Elixometer.Updater,
+  max_messages: 5000
+````
+
 ## Metrics
 
-Defining metrics in elixometer is substantially easier than in exometer. Instead of defining and then updating a metric, just update it. Also, instead of providing a list of atoms, a metric is named with a period separated bitstring. Presently, Elixometer supports timers, histograms, gauges, counters, and spirals.
+Defining metrics in elixometer is substantially easier than in exometer. Instead of defining and then updating a metric, just update it. Also, instead of providing a list of terms, a metric is named with a period separated bitstring. Presently, Elixometer supports timers, histograms, gauges, counters, and spirals.
 
 Timings may also be defined by annotating a function with a @timed annotation. This annotation takes a key argument, which tells elixometer what key to use. You  can specify `:auto` and a key will be generated from the module name and method name.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,4 +22,7 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 
+config :elixometer, Elixometer.Updater,
+  max_messages: 1000
+
 import_config "#{Mix.env}.exs"

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -174,19 +174,25 @@ defmodule Elixometer do
 
   def get_metric_value(metric_name) do
     metric_name
-    |> String.split(".")
+    |> to_exometer_key
     |> :exometer.get_value
   end
 
   def get_metric_value(metric_name, data_point) do
-    metric_val = metric_name
-    |> String.split(".")
-    |> :exometer.get_value(data_point)
+    metric_val =
+      metric_name
+      |> to_exometer_key
+      |> :exometer.get_value(data_point)
 
     case metric_val do
       {:ok, metric} -> {:ok, metric[data_point]}
       r = {:error, _reason} -> r
     end
+  end
+
+  defp to_exometer_key(metric_name) when is_list(metric_name), do: metric_name
+  defp to_exometer_key(metric_name) when is_binary(metric_name) do
+    String.split(metric_name, ".")
   end
 
   @doc """

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -174,13 +174,13 @@ defmodule Elixometer do
 
   def get_metric_value(metric_name) do
     metric_name
-    |> to_atom_list
+    |> String.split(".")
     |> :exometer.get_value
   end
 
   def get_metric_value(metric_name, data_point) do
     metric_val = metric_name
-    |> to_atom_list
+    |> String.split(".")
     |> :exometer.get_value(data_point)
 
     case metric_val do
@@ -248,11 +248,9 @@ defmodule Elixometer do
   actually provide this much granularity.
   """
   defmacro timed(name, units \\ :microsecond, do: block) do
-    converted_name = Elixometer.Utils.name_to_exometer(:timers, name)
-
     quote do
       {elapsed_us, rv} = :timer.tc(fn -> unquote(block) end)
-      Updater.timer(unquote(converted_name), unquote(units), elapsed_us)
+      Updater.timer(unquote(name), unquote(units), elapsed_us)
       rv
     end
   end
@@ -266,7 +264,7 @@ defmodule Elixometer do
   end
 
   def metric_defined?(name) when is_bitstring(name) do
-    name |> to_atom_list |> metric_defined?
+    name |> String.split(".") |> metric_defined?
   end
 
   def metric_defined?(name) do

--- a/lib/updater.ex
+++ b/lib/updater.ex
@@ -2,28 +2,26 @@ defmodule Elixometer.Updater do
   @moduledoc false
 
   @max_messages 1000
+  @default_formatter &Elixometer.Utils.name_to_exometer/2
 
   import Elixometer, only: [ensure_registered: 2, add_counter: 2, add_counter: 1]
-  import Elixometer.Utils
   use GenServer
 
   def init([]) do
-    {:ok, pobox} = :pobox.start_link(self(), @max_messages, :queue)
+    config = Application.get_env(:elixometer, __MODULE__, [])
+    max_messages = Keyword.get(config, :max_messages, @max_messages)
+    formatter = Keyword.get(config, :formatter, @default_formatter)
+    {:ok, pobox} = :pobox.start_link(self(), max_messages, :queue)
     Process.register(pobox, :elixometer_pobox)
     activate_pobox()
-    {:ok, nil}
+    {:ok, %{formatter: formatter}}
   end
 
   def start_link do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def timer(name, units, elapsed) when is_bitstring(name) do
-    elixometer_name = name_to_exometer(:timers, name)
-    timer(elixometer_name, units, elapsed)
-  end
-
-  def timer(name, units, elapsed) when is_list(name) do
+  def timer(name, units, elapsed) do
     :pobox.post(:elixometer_pobox, {:timer, name, units, elapsed})
   end
 
@@ -43,17 +41,18 @@ defmodule Elixometer.Updater do
     :pobox.post(:elixometer_pobox, {:histogram, name, delta, reset_seconds, truncate})
   end
 
-  def handle_info({:mail, _pid, messages, _, _}, state) do
-    messages
-    |> Enum.each(&do_update/1)
+  def handle_info({:mail, _pid, messages, _, _}, %{formatter: formatter} = state) do
+    Enum.each(messages, fn message ->
+      do_update(message, formatter)
+    end)
 
     activate_pobox()
 
     {:noreply, state}
   end
 
-  def do_update({:histogram, name, delta, aggregate_seconds, truncate}) do
-    monitor = name_to_exometer(:histograms, name)
+  def do_update({:histogram, name, delta, aggregate_seconds, truncate}, formatter) do
+    monitor = formatter.(:histograms, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :histogram, [time_span: :timer.seconds(aggregate_seconds), truncate: truncate])
@@ -62,8 +61,8 @@ defmodule Elixometer.Updater do
     :exometer.update(monitor, delta)
   end
 
-  def do_update({:spiral, name, delta, opts}) do
-    monitor = name_to_exometer(:spirals, name)
+  def do_update({:spiral, name, delta, opts}, formatter) do
+    monitor = formatter.(:spirals, name)
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :spiral,  opts)
     end)
@@ -71,8 +70,8 @@ defmodule Elixometer.Updater do
     :exometer.update(monitor, delta)
   end
 
-  def do_update({:counter, name, delta, reset_seconds}) do
-    monitor = name_to_exometer(:counters, name)
+  def do_update({:counter, name, delta, reset_seconds}, formatter) do
+    monitor = formatter.(:counters, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :counter, [])
@@ -87,8 +86,8 @@ defmodule Elixometer.Updater do
     :exometer.update(monitor, delta)
   end
 
-  def do_update({:gauge, name, value}) do
-    monitor = name_to_exometer(:gauges, name)
+  def do_update({:gauge, name, value}, formatter) do
+    monitor = formatter.(:gauges, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :gauge, [])
@@ -97,9 +96,11 @@ defmodule Elixometer.Updater do
     :exometer.update(monitor, value)
   end
 
-  def do_update({:timer, name, units, elapsed_us}) do
-    ensure_registered(name, fn ->
-      :exometer.new(name, :histogram, [])
+  def do_update({:timer, name, units, elapsed_us}, formatter) do
+    timer = formatter.(:timers, name)
+
+    ensure_registered(timer, fn ->
+      :exometer.new(timer, :histogram, [])
     end)
 
     elapsed_time =
@@ -110,7 +111,7 @@ defmodule Elixometer.Updater do
         units in [:second, :seconds] -> div(elapsed_us, 1_000_000)
       end
 
-    :exometer.update(name, elapsed_time)
+    :exometer.update(timer, elapsed_time)
   end
 
   defp activate_pobox do

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -15,13 +15,6 @@ defmodule Elixometer.Utils do
                   env -> "#{prefix}.#{env}.#{metric_type}.#{name}"
                 end
 
-    to_atom_list(base_name)
+    String.split(base_name, ".")
   end
-
-  def to_atom_list(s) when is_bitstring(s) do
-    s
-    |> String.split(".")
-    |> Enum.map(&String.to_atom/1)
-  end
-
 end

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -60,14 +60,8 @@ defmodule ElixometerTest do
     :timer.sleep 50
   end
 
-  defp to_elixometer_name(metric_name) when is_bitstring(metric_name) do
-    metric_name
-    |> String.split(".")
-    |> Enum.map(&String.to_atom/1)
-  end
-
   def metric_exists(metric_name) when is_bitstring(metric_name) do
-    metric_name |> to_elixometer_name |> metric_exists
+    metric_name |> String.split(".") |> metric_exists
   end
 
   def metric_exists(metric_name) when is_list(metric_name) do
@@ -76,7 +70,7 @@ defmodule ElixometerTest do
   end
 
   def subscription_exists(metric_name) when is_bitstring(metric_name) do
-    metric_name |> to_elixometer_name |> subscription_exists
+    metric_name |> String.split(".") |> subscription_exists
   end
 
   def subscription_exists(metric_name) when is_list(metric_name) do
@@ -139,7 +133,7 @@ defmodule ElixometerTest do
 
     wait_for_messages()
 
-    expected_name = [:elixometer, :test, :counters, :reset]
+    expected_name = ["elixometer", "test", "counters", "reset"]
     {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
     assert val == 1
 
@@ -158,7 +152,7 @@ defmodule ElixometerTest do
 
     wait_for_messages()
 
-    expected_name = [:elixometer, :test, :counters, :no_reset]
+    expected_name = ["elixometer", "test", "counters", "no_reset"]
     {:ok, [value: val]} = :exometer.get_value(expected_name, :value)
     assert val == 1
 

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -307,4 +307,13 @@ defmodule ElixometerTest do
     assert subscription_exists "elixometer.test.counters.subscribe_options"
     assert [some_option: 42] = Reporter.options_for("elixometer.test.counters.subscribe_options")
   end
+
+  test "metrics created elsewhere can be retrieved" do
+    foreign_metric = [:created, :somewhere]
+    :exometer.new(foreign_metric, :spiral,  [])
+    :exometer.update(foreign_metric, 100)
+
+    assert {:ok, data} = get_metric_value([:created, :somewhere])
+    assert data[:one] == 100
+  end
 end

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -37,7 +37,7 @@ defmodule Elixometer.TestReporter do
 
   def value_for(metric_name, datapoint) when is_bitstring(metric_name) do
     metric_name
-    |> to_elixometer_name
+    |> String.split(".")
     |> value_for(datapoint)
   end
 
@@ -48,7 +48,7 @@ defmodule Elixometer.TestReporter do
 
   def options_for(metric_name) when is_bitstring(metric_name) do
     metric_name
-    |> to_elixometer_name
+    |> String.split(".")
     |> options_for
   end
 
@@ -62,13 +62,5 @@ defmodule Elixometer.TestReporter do
       [hd | _] -> hd
       _        -> nil
     end
-  end
-
-  # Helpers
-
-  defp to_elixometer_name(metric_name) do
-    metric_name
-    |> String.split(".")
-    |> Enum.map(&String.to_atom/1)
   end
 end


### PR DESCRIPTION
Hello,

This PR introduces two changes:

1. All the names are now transferred as list of binaries, instead of generating atoms at runtime. This is useful for an environment where metrics are built dynamically, preventing the VM from exploding due to atoms not being garbage collected. `exometer` is perfectly fine accepting _lists of terms_ for metric identifiers.

1. New configuration options: 
  - `max_messages` - allows fine tuning the `pobox` buffer size
  - `formatter` - allows injecting a custom metric name formatting function, useful for legacy systems where metrics have already a naming scheme that needs to be preserved.

Let me know please, if this is good to go 🍻 