### PR TITLE
Allow :env to be configurable from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Metrics are prepended with the `metric_prefix`, the type of metric and the envir
 
 The optional `update_frequency` key of the :elixometer config controls the interval between reports. By default this is set to `1000` ms in the `dev` environment and `20` ms in the `test` environment.
 
+You can use an environment variable to set the `env`.
+
+```elixir
+config :elixometer, env: {:system, "ELIXOMETER_ENV"}
+```
+
 By default, metrics are formatted using `Elixometer.Utils.name_to_exometer/2`.
 This function takes care of composing metric names with prefix, environment and
 the metric type (e.g. `myapp_prefix.dev.timers.request_time`).

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -9,7 +9,7 @@ defmodule Elixometer.Utils do
   def name_to_exometer(metric_type, name) when is_bitstring(name) do
     config = Application.get_all_env(:elixometer)
     prefix = config[:metric_prefix] || "elixometer"
-    base_name = case config[:env] do
+    base_name = case env(config[:env]) do
                   nil -> "#{prefix}.#{metric_type}.#{name}"
                   :prod -> "#{prefix}.#{metric_type}.#{name}"
                   env -> "#{prefix}.#{env}.#{metric_type}.#{name}"
@@ -17,4 +17,12 @@ defmodule Elixometer.Utils do
 
     String.split(base_name, ".")
   end
+
+  defp env({:system, var}) do
+    case System.get_env(var) do
+      nil -> nil
+      v -> String.to_atom(v)
+    end
+  end
+  defp env(val), do: val
 end


### PR DESCRIPTION
In your config/config.exs you can set {:system, "ENV_VARIABLE_HERE"} to allow the
env to be set with environmental variables supplied on runtime.

```
config :elixometer, env: {:system, "ELIXOMETER_ENV"}
```