### PR TITLE
Update Travis environment to use OTP 20.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ elixir: 1.3.0
 otp_release: 18.2
 matrix:
   include:
-  - elixir: 1.4.0
-    otp_release: 19.2
+  - elixir: 1.4.5
+    otp_release: 20.0
 after_script:
   - MIX_ENV=test mix coveralls.travis
 cache:


### PR DESCRIPTION
Also bump us to the latest 1.4 release (1.4.5).