### PR TITLE
Support Elixir 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: elixir
-elixir: 1.3.0
-otp_release: 18.2
-matrix:
-  include:
-  - elixir: 1.5.1
-    otp_release: 20.0
+elixir:
+  - 1.3.0
+  - 1.5.1
+otp_release:
+  - 18.2
+  - 20.0
+sudo: false
 after_script:
   - MIX_ENV=test mix coveralls.travis
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: elixir
-elixir:
-  - 1.3.0
-  - 1.5.1
-otp_release:
-  - 18.2
-  - 20.0
+elixir: 1.5.1
+otp_release: 20.0
+matrix:
+  include:
+  - elixir: 1.3.0
+    otp_release: 18.2
+  - elixir: 1.5.1
+    otp_release: 20.0
 sudo: false
 after_script:
   - MIX_ENV=test mix coveralls.travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ elixir: 1.3.0
 otp_release: 18.2
 matrix:
   include:
-  - elixir: 1.4.5
+  - elixir: 1.5.0
     otp_release: 20.0
 after_script:
   - MIX_ENV=test mix coveralls.travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ matrix:
     otp_release: 18.2
   - elixir: 1.5.1
     otp_release: 20.0
-sudo: false
+env:
+  - MIX_ENV=test
 after_script:
-  - MIX_ENV=test mix coveralls.travis
+  - mix coveralls.travis
 cache:
   directories:
   - $HOME/.mix/archives

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ elixir: 1.3.0
 otp_release: 18.2
 matrix:
   include:
-  - elixir: 1.5.0
+  - elixir: 1.5.1
     otp_release: 20.0
 after_script:
   - MIX_ENV=test mix coveralls.travis

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -125,10 +125,10 @@ defmodule Elixometer do
   # Elixir 1.5.0-rc changed on_definition/6 to always wrap body in a keyword
   # list (e.g. `[do: body]`). For backwards compatibility, this normalization
   # function wraps earlier versions' bodies in a keyword list, too.
+  defp normalize_body(nil), do: raise "timed function must have a body"
   defp normalize_body(body) do
     case Version.compare(System.version(), "1.5.0-rc") do
       :lt -> [do: body]
-      _ when is_nil(body) -> raise "timed function must have a body"
       _ -> body
     end
   end

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -122,11 +122,12 @@ defmodule Elixometer do
     end
   end
 
-  defp build_timer_body(%Timer{} = timer_data) do
-    quote do
-      timed(unquote(timer_data.key), unquote(timer_data.units)) do
-        unquote(timer_data.body)
-      end
+  defp build_timer_body(%Timer{body: [do: block]} = timer) do
+    build_timer_body(%{timer | body: block})
+  end
+  defp build_timer_body(%Timer{} = timer) do
+    quote bind_quoted: [key: timer.key, units: timer.units, body: timer.body] do
+      timed key, units, do: body
     end
   end
 

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -125,10 +125,10 @@ defmodule Elixometer do
   # Elixir 1.5.0-rc changed on_definition/6 to always wrap body in a keyword
   # list (e.g. `[do: body]`). For backwards compatibility, this normalization
   # function wraps earlier versions' bodies in a keyword list, too.
-  defp normalize_body(nil), do: raise "timed function must have a body"
   defp normalize_body(body) do
     case Version.compare(System.version(), "1.5.0-rc") do
       :lt -> [do: body]
+      _ when is_nil(body) -> raise "timed function must have a body"
       _ -> body
     end
   end

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -215,14 +215,49 @@ defmodule ElixometerTest do
     assert ns > 1_000_000
   end
 
-  test "a bodyless timer raises a RuntimeError" do
+  test "a bodyless timer defined in a module raises a RuntimeError" do
+    on_exit(fn ->
+      :code.delete(TimedBodylessModule)
+      :code.purge(TimedBodylessModule)
+    end)
+
     assert_raise RuntimeError, "timed function must have a body", fn ->
-      defmodule Inner do
+      defmodule TimedBodylessModule do
         use Elixometer
-        @timed(key: "bodyless")
+        @timed(key: :auto)
         def bodyless
       end
     end
+  end
+
+  test "a timer defined in a module can return nil" do
+    on_exit(fn ->
+      :code.delete(TimedNilModule)
+      :code.purge(TimedNilModule)
+    end)
+
+    defmodule TimedNilModule do
+      use Elixometer
+      @timed(key: :auto)
+      def fun(), do: nil
+    end
+
+    assert TimedNilModule.fun() == nil
+  end
+
+  test "a timer defined in a module can return an AST body" do
+    on_exit(fn ->
+      :code.delete(TimedASTModule)
+      :code.purge(TimedASTModule)
+    end)
+
+    defmodule TimedASTModule do
+      use Elixometer
+      @timed(key: :auto)
+      def fun(), do: [do: :value]
+    end
+
+    assert TimedASTModule.fun() == [do: :value]
   end
 
   test "a timer defined in the module's declaration" do

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -47,9 +47,7 @@ defmodule ElixometerTest do
 
     @timed(key: :auto)
     def auto_named do
-
     end
-
   end
 
   setup do
@@ -215,6 +213,16 @@ defmodule ElixometerTest do
     assert subscription_exists "elixometer.test.timers.nanosecond"
     [{99, ns}] = Reporter.value_for("elixometer.test.timers.nanosecond", 99)
     assert ns > 1_000_000
+  end
+
+  test "a bodyless timer raises a RuntimeError" do
+    assert_raise RuntimeError, "timed function must have a body", fn ->
+      defmodule Inner do
+        use Elixometer
+        @timed(key: "bodyless")
+        def bodyless
+      end
+    end
   end
 
   test "a timer defined in the module's declaration" do

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -221,6 +221,7 @@ defmodule ElixometerTest do
     assert ns > 1_000_000
   end
 
+  @tag elixir: 1.5
   test "a bodyless timer defined in a module raises a RuntimeError" do
     on_exit(fn ->
       :code.delete(BodylessModule)

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -218,9 +218,7 @@ defmodule ElixometerTest do
   end
 
   test "a timer defined in the module's declaration" do
-    rv = DeclarativeTest.my_timed_method(1, 2, 3, 4)
-
-    assert rv == 1 + 2 + 3 + 4
+    assert DeclarativeTest.my_timed_method(1, 2, 3, 4) == 10
     assert metric_exists "elixometer.test.timers.declarative_test.my_timed_method"
   end
 

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -55,11 +55,9 @@ defmodule Elixometer.TestReporter do
   def options_for(metric_name) do
     Application.get_env(:elixometer, :reporter)
     |> :exometer_report.list_subscriptions
-    |> Enum.filter(fn {name, _, _, _}  -> name == metric_name end)
-    |> Enum.map(fn {_, _, _, extra} -> extra end)
-    |> case do
-      [hd | _] -> hd
-      _        -> nil
-    end
+    |> Enum.find_value(fn
+      {^metric_name, _, _, extra} -> extra
+      _ -> nil
+    end)
   end
 end

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -55,9 +55,8 @@ defmodule Elixometer.TestReporter do
   def options_for(metric_name) do
     Application.get_env(:elixometer, :reporter)
     |> :exometer_report.list_subscriptions
-    |> Enum.filter_map(
-      fn {name, _, _, _}  -> name == metric_name end,
-      fn {_, _, _, extra} -> extra end)
+    |> Enum.filter(fn {name, _, _, _}  -> name == metric_name end)
+    |> Enum.map(fn {_, _, _, extra} -> extra end)
     |> case do
       [hd | _] -> hd
       _        -> nil

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
+# Exclude Elixir 1.5-tagged tests when running on earlier versions.
+if Version.compare(System.version(), "1.5.0-rc") == :lt do
+  ExUnit.configure(exclude: [elixir: 1.5])
+end
+
 ExUnit.start()


### PR DESCRIPTION
In addition to bumping Travis's Elixir version to 1.5.1, this change adds
support for an Elixir 1.5 change to `@on_definition`. From the [Elixir 1.5
release notes](https://github.com/elixir-lang/elixir/blob/v1.5/CHANGELOG.md):

> The `on_definition/6` callback now receives `body` wrapped in a keyword
> list, such as `[do: body]`. This solves a bug where it was impossible to
> distinguish between a bodyless clause and a function that returns `nil`.