### PR TITLE
Add filtering of (metric, datapoint) from config blacklist on subscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ config :elixometer, Elixometer.Updater,
   max_messages: 5000
 ```
 
-### Blacklisting datapoints subscriptions
+### Excluding datapoints subscriptions
 
 By default, adding a histogram adds for example 11 subscriptions (`[:n, :mean, :min, :max, :median, 50, 75, 90, 95, 99, 999]`).
-If you would like to restrict which of these you care about, you can blacklist some with the blacklist like so:
+If you would like to restrict which of these you care about, you can exclude some like so:
 
 ```elixir
-config :elixometer, datapoints_blacklist: [:median, :999]
+config :elixometer, excluded_datapoints: [:median, :999]
 ```
 
 ## Metrics

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The optional `update_frequency` key of the :elixometer config controls the inter
 
 You can use an environment variable to set the `env`.
 
+
 ```elixir
 config :elixometer, env: {:system, "ELIXOMETER_ENV"}
 ```
@@ -64,6 +65,15 @@ A maximum size of message buffer, defaulting to 1000, can be configured with:
 ```elixir
 config :elixometer, Elixometer.Updater,
   max_messages: 5000
+```
+
+### Blacklisting datapoints subscriptions
+
+By default, adding a histogram adds for example 11 subscriptions (`[:n, :mean, :min, :max, :median, 50, 75, 90, 95, 99, 999]`).
+If you would like to restrict which of these you care about, you can blacklist some with the blacklist like so:
+
+```elixir
+config :elixometer, datapoints_blacklist: [:median, :999]
 ```
 
 ## Metrics

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -75,6 +75,7 @@ defmodule Elixometer do
   end
 
   @elixometer_table :elixometer
+
   alias Elixometer.Updater
   import Elixometer.Utils
   use GenServer
@@ -369,13 +370,13 @@ defmodule Elixometer do
       reporter = cfg[:reporter]
       interval = cfg[:update_frequency]
       subscribe_options = cfg[:subscribe_options] || []
-      datapoints_blacklist = cfg[:datapoints_blacklist] || []
+      excluded_datapoints = cfg[:excluded_datapoints] || []
 
       if reporter do
         metric_name
         |> :exometer.info
         |> Keyword.get(:datapoints)
-        |> Enum.reject(&Enum.member?(datapoints_blacklist, &1))
+        |> Enum.reject(&Enum.member?(excluded_datapoints, &1))
         |> Enum.map(&(:exometer_report.subscribe(reporter, metric_name, &1, interval, subscribe_options)))
       end
       :ets.insert(@elixometer_table, {{:subscriptions, metric_name}, true})

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -369,11 +369,13 @@ defmodule Elixometer do
       reporter = cfg[:reporter]
       interval = cfg[:update_frequency]
       subscribe_options = cfg[:subscribe_options] || []
+      datapoints_blacklist = cfg[:datapoints_blacklist] || []
 
       if reporter do
         metric_name
         |> :exometer.info
         |> Keyword.get(:datapoints)
+        |> Enum.filter(fn(datapoint) -> not Enum.member?(datapoints_blacklist, datapoint) end) 
         |> Enum.map(&(:exometer_report.subscribe(reporter, metric_name, &1, interval, subscribe_options)))
       end
       :ets.insert(@elixometer_table, {{:subscriptions, metric_name}, true})

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -75,7 +75,6 @@ defmodule Elixometer do
   end
 
   @elixometer_table :elixometer
-
   alias Elixometer.Updater
   import Elixometer.Utils
   use GenServer

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -375,7 +375,7 @@ defmodule Elixometer do
         metric_name
         |> :exometer.info
         |> Keyword.get(:datapoints)
-        |> Enum.filter(fn(datapoint) -> not Enum.member?(datapoints_blacklist, datapoint) end) 
+        |> Enum.reject(&Enum.member?(datapoints_blacklist, &1))
         |> Enum.map(&(:exometer_report.subscribe(reporter, metric_name, &1, interval, subscribe_options)))
       end
       :ets.insert(@elixometer_table, {{:subscriptions, metric_name}, true})

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -67,46 +67,55 @@ defmodule ElixometerTest do
     :timer.sleep 50
   end
 
-  def metric_exists(metric_name) when is_bitstring(metric_name) do
-    metric_name |> String.split(".") |> metric_exists
+  defp metric_exists?(metric_name) when is_bitstring(metric_name) do
+    metric_name |> String.split(".") |> metric_exists?
   end
 
-  def metric_exists(metric_name) when is_list(metric_name) do
+  defp metric_exists?(metric_name) when is_list(metric_name) do
     wait_for_messages()
     metric_name in Reporter.metric_names
   end
 
-  def subscription_exists(metric_name) when is_bitstring(metric_name) do
-    metric_name |> String.split(".") |> subscription_exists
+  defp subscription_exists?(metric_name) when is_bitstring(metric_name) do
+    metric_name |> String.split(".") |> subscription_exists?
   end
 
-  def subscription_exists(metric_name) when is_list(metric_name) do
+  defp subscription_exists?(metric_name) when is_list(metric_name) do
     wait_for_messages()
-    metric_name in Reporter.subscriptions
+    metric_name in Reporter.subscription_names
+  end
+
+  defp subscription_exists?(metric_name, datapoint) when is_bitstring(metric_name) do
+    metric_name |> String.split(".") |> subscription_exists?(datapoint)
+  end
+
+  defp subscription_exists?(metric_name, datapoint) when is_list(metric_name) do
+    wait_for_messages()
+    {metric_name, datapoint} in Reporter.subscriptions
   end
 
   test "a gauge registers its name" do
     update_gauge("register", 10)
 
-    assert metric_exists "elixometer.test.gauges.register"
+    assert metric_exists? "elixometer.test.gauges.register"
   end
 
   test "a gauge automatically subscribes" do
     update_gauge("subscription", 10)
 
-    assert subscription_exists "elixometer.test.gauges.subscription"
+    assert subscription_exists? "elixometer.test.gauges.subscription"
   end
 
   test "a histogram registers its name" do
     update_histogram("register", 10)
 
-    assert metric_exists "elixometer.test.histograms.register"
+    assert metric_exists? "elixometer.test.histograms.register"
   end
 
   test "a histogram automatically subscribes" do
     update_histogram("subscription", 1)
 
-    assert subscription_exists "elixometer.test.histograms.subscription"
+    assert subscription_exists? "elixometer.test.histograms.subscription"
   end
 
   test "a histogram does not truncate percentiles" do
@@ -126,13 +135,13 @@ defmodule ElixometerTest do
   test "a counter registers its name" do
     update_counter("register", 1)
 
-    assert metric_exists "elixometer.test.counters.register"
+    assert metric_exists? "elixometer.test.counters.register"
   end
 
   test "a counter automatically subscribes" do
     update_counter("subscription", 1)
 
-    assert subscription_exists "elixometer.test.counters.subscription"
+    assert subscription_exists? "elixometer.test.counters.subscription"
   end
 
   test "clearing a counter sets it to 0" do
@@ -145,7 +154,7 @@ defmodule ElixometerTest do
     clear_counter("to_be_cleared")
     assert {:ok, [value: 0]} == :exometer.get_value(name, :value)
 
-   assert metric_exists "elixometer.test.counters.to_be_cleared"
+   assert metric_exists? "elixometer.test.counters.to_be_cleared"
   end
 
   test "a counter resets itself after its time has elapsed" do
@@ -193,19 +202,19 @@ defmodule ElixometerTest do
   test "a timer registers its name" do
     timed("register", do: 1 + 1)
 
-    assert metric_exists "elixometer.test.timers.register"
+    assert metric_exists? "elixometer.test.timers.register"
   end
 
   test "a timer automatically subscribes" do
     timed("subscription", do: 1 + 1)
 
-    assert subscription_exists "elixometer.test.timers.subscription"
+    assert subscription_exists? "elixometer.test.timers.subscription"
   end
 
   test "a timer can time in seconds" do
     timed("second", :second, do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.second"
+    assert subscription_exists? "elixometer.test.timers.second"
     [{99, s}] = Reporter.value_for("elixometer.test.timers.second", 99)
     assert s <= 1
   end
@@ -213,7 +222,7 @@ defmodule ElixometerTest do
   test "a timer can time in milliseconds" do
     timed("millisecond", :millisecond, do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.millisecond"
+    assert subscription_exists? "elixometer.test.timers.millisecond"
     [{99, ms}] = Reporter.value_for("elixometer.test.timers.millisecond", 99)
     assert ms <= 10
   end
@@ -221,7 +230,7 @@ defmodule ElixometerTest do
   test "a timer times in microseconds by default" do
     timed("microsecond", do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.microsecond"
+    assert subscription_exists? "elixometer.test.timers.microsecond"
     [{_data_point, value}] = Reporter.value_for("elixometer.test.timers.microsecond", 99)
     assert value > 1000
   end
@@ -229,7 +238,7 @@ defmodule ElixometerTest do
   test "a timer can time in nanoseconds" do
     timed("nanosecond", :nanosecond, do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.nanosecond"
+    assert subscription_exists? "elixometer.test.timers.nanosecond"
     [{99, ns}] = Reporter.value_for("elixometer.test.timers.nanosecond", 99)
     assert ns > 1_000_000
   end
@@ -251,56 +260,56 @@ defmodule ElixometerTest do
   end
   test "a timer defined in the module's declaration" do
     assert DeclarativeTest.my_timed_method(1, 2, 3, 4) == 10
-    assert metric_exists "elixometer.test.timers.declarative_test.my_timed_method"
+    assert metric_exists? "elixometer.test.timers.declarative_test.my_timed_method"
   end
 
   test "a timer defined in the module's definition is specific to an arity" do
     DeclarativeTest.arity_test(1)
 
-    refute metric_exists "elixometer.test.timers.arity_test"
+    refute metric_exists? "elixometer.test.timers.arity_test"
 
     DeclarativeTest.arity_test(1, 2)
-    assert metric_exists "elixometer.test.timers.arity_test"
+    assert metric_exists? "elixometer.test.timers.arity_test"
   end
 
   test "a timer defined with attributes and docs" do
     DeclarativeTest.timed_with_doc
 
-    assert metric_exists "elixometer.test.timers.timed_with_doc"
+    assert metric_exists? "elixometer.test.timers.timed_with_doc"
   end
 
   test "a timer defined with attributes works with defp" do
     DeclarativeTest.public_secret_timed
 
-    assert metric_exists "elixometer.test.timers.defp_timed"
+    assert metric_exists? "elixometer.test.timers.defp_timed"
   end
 
   test "a timer defined with no key auto generates one" do
     DeclarativeTest.auto_named
 
-    assert metric_exists "elixometer.test.timers.elixometer_test.declarative_test.auto_named"
+    assert metric_exists? "elixometer.test.timers.elixometer_test.declarative_test.auto_named"
   end
 
   test "a timer defined in a module can return nil" do
     assert DeclarativeTest.timed_returning_nil() == nil
-    assert metric_exists "elixometer.test.timers.returning_nil"
+    assert metric_exists? "elixometer.test.timers.returning_nil"
   end
 
   test "a timer defined in a module can return an AST body" do
     assert DeclarativeTest.timed_returning_ast() == [do: :value]
-    assert metric_exists "elixometer.test.timers.returning_ast"
+    assert metric_exists? "elixometer.test.timers.returning_ast"
   end
 
   test "a spiral registers its name" do
     update_spiral("register", 1)
 
-    assert metric_exists "elixometer.test.spirals.register"
+    assert metric_exists? "elixometer.test.spirals.register"
   end
 
   test "a spiral subscribes" do
     update_spiral("subscription", 1)
 
-    assert subscription_exists "elixometer.test.spirals.subscription"
+    assert subscription_exists? "elixometer.test.spirals.subscription"
   end
 
   test "name can be precomputed" do
@@ -374,12 +383,9 @@ defmodule ElixometerTest do
     # Remove :median from the subscriptions
     Application.put_env(:elixometer, :excluded_datapoints, [:median])
     update_histogram "uniquelittlefoobar", 42
-    wait_for_messages()
     key = ["elixometer", "test", "histograms", "uniquelittlefoobar"]
-    datapoints = :exometer.info(key)[:datapoints]
-    subscriptions = Enum.filter(Reporter.subscriptions, fn x -> x == key end)
 
-    assert length(subscriptions) < length(datapoints)
+    refute subscription_exists?(key, :median)
   end
 
   test "getting a datapoint from a metric that doesn't exist" do
@@ -391,7 +397,7 @@ defmodule ElixometerTest do
 
     update_counter("subscribe_options", 1)
 
-    assert subscription_exists "elixometer.test.counters.subscribe_options"
+    assert subscription_exists? "elixometer.test.counters.subscribe_options"
     assert [some_option: 42] = Reporter.options_for("elixometer.test.counters.subscribe_options")
 
   end

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -372,7 +372,7 @@ defmodule ElixometerTest do
 
   test "blacklisting subscriptions works" do
     # Remove :median from the subscriptions
-    Application.put_env(:elixometer, :datapoints_blacklist, [:median])
+    Application.put_env(:elixometer, :excluded_datapoints, [:median])
     update_histogram "uniquelittlefoobar", 42
     wait_for_messages()
     key = ["elixometer", "test", "histograms", "uniquelittlefoobar"]

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -370,6 +370,18 @@ defmodule ElixometerTest do
 
   end
 
+  test "blacklisting subscriptions works" do
+    # Remove :median from the subscriptions
+    Application.put_env(:elixometer, :datapoints_blacklist, [:median])
+    update_histogram "uniquelittlefoobar", 42
+    wait_for_messages()
+    key = ["elixometer", "test", "histograms", "uniquelittlefoobar"]
+    datapoints = :exometer.info(key)[:datapoints]
+    subscriptions = Enum.filter(Reporter.subscriptions, fn x -> x == key end)
+
+    assert length(subscriptions) < length(datapoints)
+  end
+
   test "getting a datapoint from a metric that doesn't exist" do
     assert {:error, :not_found} == get_metric_value("elixometer.test.bad.bad")
   end
@@ -381,6 +393,7 @@ defmodule ElixometerTest do
 
     assert subscription_exists "elixometer.test.counters.subscribe_options"
     assert [some_option: 42] = Reporter.options_for("elixometer.test.counters.subscribe_options")
+
   end
 
   test "metrics created elsewhere can be retrieved" do

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -32,7 +32,11 @@ defmodule Elixometer.TestReporter do
   def subscriptions do
     Application.get_env(:elixometer, :reporter)
     |> :exometer_report.list_subscriptions
-    |> Enum.map(fn({metric_name, _, _, _}) -> metric_name end)
+    |> Enum.map(fn({metric_name, datapoint, _, _}) -> {metric_name, datapoint} end)
+  end
+
+  def subscription_names do
+    Enum.map(subscriptions(), fn({name, _datapoint}) -> name end)
   end
 
   def value_for(metric_name, datapoint) when is_bitstring(metric_name) do


### PR DESCRIPTION
Fixes #37 (Use mechanism to whitelist subscriptions)


Done criteria:
 - [x] functionality 
 - [x] tests