### PR TITLE
Add support for datapoints in subscriptions in test reporter

### DIFF
--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -76,20 +76,20 @@ defmodule ElixometerTest do
     metric_name in Reporter.metric_names
   end
 
-  def subscription_exists(metric_name) when is_bitstring(metric_name) do
-    metric_name |> String.split(".") |> subscription_exists
+  def subscription_exists?(metric_name) when is_bitstring(metric_name) do
+    metric_name |> String.split(".") |> subscription_exists?
   end
 
-  def subscription_exists(metric_name) when is_list(metric_name) do
+  def subscription_exists?(metric_name) when is_list(metric_name) do
     wait_for_messages()
     metric_name in Reporter.subscription_names
   end
 
-  def subscription_exists(metric_name, datapoint) when is_bitstring(metric_name) do
-    metric_name |> String.split(".") |> subscription_exists(datapoint)
+  def subscription_exists?(metric_name, datapoint) when is_bitstring(metric_name) do
+    metric_name |> String.split(".") |> subscription_exists?(datapoint)
   end
 
-  def subscription_exists(metric_name, datapoint) when is_list(metric_name) do
+  def subscription_exists?(metric_name, datapoint) when is_list(metric_name) do
     wait_for_messages()
     {metric_name, datapoint} in Reporter.subscriptions
   end
@@ -103,7 +103,7 @@ defmodule ElixometerTest do
   test "a gauge automatically subscribes" do
     update_gauge("subscription", 10)
 
-    assert subscription_exists "elixometer.test.gauges.subscription"
+    assert subscription_exists? "elixometer.test.gauges.subscription"
   end
 
   test "a histogram registers its name" do
@@ -115,7 +115,7 @@ defmodule ElixometerTest do
   test "a histogram automatically subscribes" do
     update_histogram("subscription", 1)
 
-    assert subscription_exists "elixometer.test.histograms.subscription"
+    assert subscription_exists? "elixometer.test.histograms.subscription"
   end
 
   test "a histogram does not truncate percentiles" do
@@ -141,7 +141,7 @@ defmodule ElixometerTest do
   test "a counter automatically subscribes" do
     update_counter("subscription", 1)
 
-    assert subscription_exists "elixometer.test.counters.subscription"
+    assert subscription_exists? "elixometer.test.counters.subscription"
   end
 
   test "clearing a counter sets it to 0" do
@@ -208,13 +208,13 @@ defmodule ElixometerTest do
   test "a timer automatically subscribes" do
     timed("subscription", do: 1 + 1)
 
-    assert subscription_exists "elixometer.test.timers.subscription"
+    assert subscription_exists? "elixometer.test.timers.subscription"
   end
 
   test "a timer can time in seconds" do
     timed("second", :second, do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.second"
+    assert subscription_exists? "elixometer.test.timers.second"
     [{99, s}] = Reporter.value_for("elixometer.test.timers.second", 99)
     assert s <= 1
   end
@@ -222,7 +222,7 @@ defmodule ElixometerTest do
   test "a timer can time in milliseconds" do
     timed("millisecond", :millisecond, do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.millisecond"
+    assert subscription_exists? "elixometer.test.timers.millisecond"
     [{99, ms}] = Reporter.value_for("elixometer.test.timers.millisecond", 99)
     assert ms <= 10
   end
@@ -230,7 +230,7 @@ defmodule ElixometerTest do
   test "a timer times in microseconds by default" do
     timed("microsecond", do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.microsecond"
+    assert subscription_exists? "elixometer.test.timers.microsecond"
     [{_data_point, value}] = Reporter.value_for("elixometer.test.timers.microsecond", 99)
     assert value > 1000
   end
@@ -238,7 +238,7 @@ defmodule ElixometerTest do
   test "a timer can time in nanoseconds" do
     timed("nanosecond", :nanosecond, do: :timer.sleep(1))
 
-    assert subscription_exists "elixometer.test.timers.nanosecond"
+    assert subscription_exists? "elixometer.test.timers.nanosecond"
     [{99, ns}] = Reporter.value_for("elixometer.test.timers.nanosecond", 99)
     assert ns > 1_000_000
   end
@@ -309,7 +309,7 @@ defmodule ElixometerTest do
   test "a spiral subscribes" do
     update_spiral("subscription", 1)
 
-    assert subscription_exists "elixometer.test.spirals.subscription"
+    assert subscription_exists? "elixometer.test.spirals.subscription"
   end
 
   test "name can be precomputed" do
@@ -385,7 +385,7 @@ defmodule ElixometerTest do
     update_histogram "uniquelittlefoobar", 42
     key = ["elixometer", "test", "histograms", "uniquelittlefoobar"]
 
-    assert not subscription_exists(key, :median)
+    refute subscription_exists?(key, :median)
   end
 
   test "getting a datapoint from a metric that doesn't exist" do
@@ -397,7 +397,7 @@ defmodule ElixometerTest do
 
     update_counter("subscribe_options", 1)
 
-    assert subscription_exists "elixometer.test.counters.subscribe_options"
+    assert subscription_exists? "elixometer.test.counters.subscribe_options"
     assert [some_option: 42] = Reporter.options_for("elixometer.test.counters.subscribe_options")
 
   end

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -67,29 +67,29 @@ defmodule ElixometerTest do
     :timer.sleep 50
   end
 
-  def metric_exists(metric_name) when is_bitstring(metric_name) do
-    metric_name |> String.split(".") |> metric_exists
+  defp metric_exists?(metric_name) when is_bitstring(metric_name) do
+    metric_name |> String.split(".") |> metric_exists?
   end
 
-  def metric_exists(metric_name) when is_list(metric_name) do
+  defp metric_exists?(metric_name) when is_list(metric_name) do
     wait_for_messages()
     metric_name in Reporter.metric_names
   end
 
-  def subscription_exists?(metric_name) when is_bitstring(metric_name) do
+  defp subscription_exists?(metric_name) when is_bitstring(metric_name) do
     metric_name |> String.split(".") |> subscription_exists?
   end
 
-  def subscription_exists?(metric_name) when is_list(metric_name) do
+  defp subscription_exists?(metric_name) when is_list(metric_name) do
     wait_for_messages()
     metric_name in Reporter.subscription_names
   end
 
-  def subscription_exists?(metric_name, datapoint) when is_bitstring(metric_name) do
+  defp subscription_exists?(metric_name, datapoint) when is_bitstring(metric_name) do
     metric_name |> String.split(".") |> subscription_exists?(datapoint)
   end
 
-  def subscription_exists?(metric_name, datapoint) when is_list(metric_name) do
+  defp subscription_exists?(metric_name, datapoint) when is_list(metric_name) do
     wait_for_messages()
     {metric_name, datapoint} in Reporter.subscriptions
   end
@@ -97,7 +97,7 @@ defmodule ElixometerTest do
   test "a gauge registers its name" do
     update_gauge("register", 10)
 
-    assert metric_exists "elixometer.test.gauges.register"
+    assert metric_exists? "elixometer.test.gauges.register"
   end
 
   test "a gauge automatically subscribes" do
@@ -109,7 +109,7 @@ defmodule ElixometerTest do
   test "a histogram registers its name" do
     update_histogram("register", 10)
 
-    assert metric_exists "elixometer.test.histograms.register"
+    assert metric_exists? "elixometer.test.histograms.register"
   end
 
   test "a histogram automatically subscribes" do
@@ -135,7 +135,7 @@ defmodule ElixometerTest do
   test "a counter registers its name" do
     update_counter("register", 1)
 
-    assert metric_exists "elixometer.test.counters.register"
+    assert metric_exists? "elixometer.test.counters.register"
   end
 
   test "a counter automatically subscribes" do
@@ -154,7 +154,7 @@ defmodule ElixometerTest do
     clear_counter("to_be_cleared")
     assert {:ok, [value: 0]} == :exometer.get_value(name, :value)
 
-   assert metric_exists "elixometer.test.counters.to_be_cleared"
+   assert metric_exists? "elixometer.test.counters.to_be_cleared"
   end
 
   test "a counter resets itself after its time has elapsed" do
@@ -202,7 +202,7 @@ defmodule ElixometerTest do
   test "a timer registers its name" do
     timed("register", do: 1 + 1)
 
-    assert metric_exists "elixometer.test.timers.register"
+    assert metric_exists? "elixometer.test.timers.register"
   end
 
   test "a timer automatically subscribes" do
@@ -260,50 +260,50 @@ defmodule ElixometerTest do
   end
   test "a timer defined in the module's declaration" do
     assert DeclarativeTest.my_timed_method(1, 2, 3, 4) == 10
-    assert metric_exists "elixometer.test.timers.declarative_test.my_timed_method"
+    assert metric_exists? "elixometer.test.timers.declarative_test.my_timed_method"
   end
 
   test "a timer defined in the module's definition is specific to an arity" do
     DeclarativeTest.arity_test(1)
 
-    refute metric_exists "elixometer.test.timers.arity_test"
+    refute metric_exists? "elixometer.test.timers.arity_test"
 
     DeclarativeTest.arity_test(1, 2)
-    assert metric_exists "elixometer.test.timers.arity_test"
+    assert metric_exists? "elixometer.test.timers.arity_test"
   end
 
   test "a timer defined with attributes and docs" do
     DeclarativeTest.timed_with_doc
 
-    assert metric_exists "elixometer.test.timers.timed_with_doc"
+    assert metric_exists? "elixometer.test.timers.timed_with_doc"
   end
 
   test "a timer defined with attributes works with defp" do
     DeclarativeTest.public_secret_timed
 
-    assert metric_exists "elixometer.test.timers.defp_timed"
+    assert metric_exists? "elixometer.test.timers.defp_timed"
   end
 
   test "a timer defined with no key auto generates one" do
     DeclarativeTest.auto_named
 
-    assert metric_exists "elixometer.test.timers.elixometer_test.declarative_test.auto_named"
+    assert metric_exists? "elixometer.test.timers.elixometer_test.declarative_test.auto_named"
   end
 
   test "a timer defined in a module can return nil" do
     assert DeclarativeTest.timed_returning_nil() == nil
-    assert metric_exists "elixometer.test.timers.returning_nil"
+    assert metric_exists? "elixometer.test.timers.returning_nil"
   end
 
   test "a timer defined in a module can return an AST body" do
     assert DeclarativeTest.timed_returning_ast() == [do: :value]
-    assert metric_exists "elixometer.test.timers.returning_ast"
+    assert metric_exists? "elixometer.test.timers.returning_ast"
   end
 
   test "a spiral registers its name" do
     update_spiral("register", 1)
 
-    assert metric_exists "elixometer.test.spirals.register"
+    assert metric_exists? "elixometer.test.spirals.register"
   end
 
   test "a spiral subscribes" do

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -32,7 +32,12 @@ defmodule Elixometer.TestReporter do
   def subscriptions do
     Application.get_env(:elixometer, :reporter)
     |> :exometer_report.list_subscriptions
-    |> Enum.map(fn({metric_name, _, _, _}) -> metric_name end)
+    |> Enum.map(fn({metric_name, datapoint, _, _}) -> {metric_name, datapoint} end)
+  end
+
+  def subscription_names do
+    subscriptions()
+    |> Enum.map(fn({name, datapoint}) -> name end)
   end
 
   def value_for(metric_name, datapoint) when is_bitstring(metric_name) do

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -36,7 +36,7 @@ defmodule Elixometer.TestReporter do
   end
 
   def subscription_names do
-    Enum.map(subscriptions, fn({name, datapoint}) -> name end)
+    Enum.map(subscriptions, fn({name, _datapoint}) -> name end)
   end
 
   def value_for(metric_name, datapoint) when is_bitstring(metric_name) do

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -36,8 +36,7 @@ defmodule Elixometer.TestReporter do
   end
 
   def subscription_names do
-    subscriptions()
-    |> Enum.map(fn({name, datapoint}) -> name end)
+    Enum.map(subscriptions, fn({name, datapoint}) -> name end)
   end
 
   def value_for(metric_name, datapoint) when is_bitstring(metric_name) do

--- a/test/support/test_reporter.ex
+++ b/test/support/test_reporter.ex
@@ -36,7 +36,7 @@ defmodule Elixometer.TestReporter do
   end
 
   def subscription_names do
-    Enum.map(subscriptions, fn({name, _datapoint}) -> name end)
+    Enum.map(subscriptions(), fn({name, _datapoint}) -> name end)
   end
 
   def value_for(metric_name, datapoint) when is_bitstring(metric_name) do


### PR DESCRIPTION
I'm adding a separate PR to tackle the fact that we were swallowing datapoint information in the `testReporter`. This allows for more robust testing of my datapoints blacklist feature. 

I'll merge this first into that branch once it's reviewed, then we can proceed to merge #91 into master