### PR TITLE
Add wildcard key support

### DIFF
--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -225,7 +225,7 @@ defmodule Elixometer do
   end
 
   defp get_values_total(values, data_point) do
-    result = Enum.reduce_while(values, 0, fn({_, attrs}, total) ->
+    Enum.reduce_while(values, 0, fn({_, attrs}, total) ->
       case Keyword.get(attrs, data_point) do
         nil -> {:halt, :not_found}
         value -> {:cont, total + value}

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -220,7 +220,7 @@ defmodule Elixometer do
     String.split(metric_name, ".")
   end
 
-  defp get_values(key) do
+  defp get_values(key) when is_list(key) do
     :exometer.get_values((key -- ["_"]) ++ [:_]) 
   end
 

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -358,12 +358,30 @@ defmodule ElixometerTest do
     assert :exometer.get_value([:elixometer, :test, :gauges, :value]) == get_metric_value("elixometer.test.gauges.value")
   end
 
+  test "getting a value with no arguments for a wildcard key" do
+    update_gauge "user1", 100
+    update_gauge "user2", 15
+
+    wait_for_messages()
+
+    assert :exometer.get_values(["elixometer", "test", "gauges", :_]) == get_metric_values("elixometer.test.gauges._")
+  end
+
   test "getting a specific metric" do
     update_gauge "value_2", 23
 
     wait_for_messages()
 
     assert {:ok, 23} == get_metric_value("elixometer.test.gauges.value_2", :value)
+  end
+
+  test "getting a specific metric for a wildcard key" do
+    update_gauge "user1", 100
+    update_gauge "user2", 15
+
+    wait_for_messages()
+
+    assert {:ok, 115} == get_metric_values("elixometer.test.gauges._", :value)
   end
 
   test "getting a value for a metric that doesn't exist" do

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -376,12 +376,12 @@ defmodule ElixometerTest do
   end
 
   test "getting a specific metric for a wildcard key" do
-    update_gauge "user1", 100
-    update_gauge "user2", 15
+    update_gauge "users.registered", 100
+    update_gauge "users.anonymous", 15
 
     wait_for_messages()
 
-    assert {:ok, 115} == get_metric_values("elixometer.test.gauges._", :value)
+    assert {:ok, 115} == get_metric_values("elixometer.test.gauges.users._", :value)
   end
 
   test "getting a value for a metric that doesn't exist" do


### PR DESCRIPTION
Hello,
This PR fixes #89 by  adding two new methods for handling wildcard keys: `get_metric_values/1` and `get_metric_values/2`. 