### PR TITLE
Fix timed function attribute to time body

### DIFF
--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -133,9 +133,7 @@ defmodule Elixometer do
   end
 
   defp build_timer_body(%Timer{key: key, units: units, body: [do: body]}) do
-    quote bind_quoted: [key: key, units: units, body: body] do
-      timed key, units, do: body
-    end
+    build_timer(key, units, body)
   end
 
   defmacro __before_compile__(env) do
@@ -292,6 +290,10 @@ defmodule Elixometer do
   actually provide this much granularity.
   """
   defmacro timed(name, units \\ :microsecond, do: block) do
+    build_timer(name, units, block)
+  end
+
+  defp build_timer(name, units, block) do
     quote do
       {elapsed_us, rv} = :timer.tc(fn -> unquote(block) end)
       Updater.timer(unquote(name), unquote(units), elapsed_us)

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -54,6 +54,9 @@ defmodule ElixometerTest do
 
     @timed(key: "returning_ast")
     def timed_returning_ast(), do: [do: :value]
+
+    @timed(key: "sleep", units: :millisecond)
+    def timed_sleep(duration), do: :timer.sleep(duration)
   end
 
   setup do
@@ -258,6 +261,14 @@ defmodule ElixometerTest do
       end
     end
   end
+
+  test "a timer defined with attributes measures time" do
+    DeclarativeTest.timed_sleep(100)
+    assert subscription_exists? "elixometer.test.timers.sleep"
+    [{99, ns}] = Reporter.value_for("elixometer.test.timers.sleep", 99)
+    assert ns in 100..1_000
+  end
+
   test "a timer defined in the module's declaration" do
     assert DeclarativeTest.my_timed_method(1, 2, 3, 4) == 10
     assert metric_exists? "elixometer.test.timers.declarative_test.my_timed_method"


### PR DESCRIPTION
bind_quoted binds variables to the results of the quoted values and
prepends those to the new quoted expression. Then uses the variables
in the remainder of the quoted expression. This caused the body to be
evaluated before the timer and the timer would only measure
fn -> result end.

Closes #100 