### PR TITLE
Fix `excluded_datapoints` README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ By default, adding a histogram adds for example 11 subscriptions (`[:n, :mean, :
 If you would like to restrict which of these you care about, you can exclude some like so:
 
 ```elixir
-config :elixometer, excluded_datapoints: [:median, :999]
+config :elixometer, excluded_datapoints: [:median, 999]
 ```
 
 ## Metrics


### PR DESCRIPTION
The syntax used in the example for `excluded_datapoints` is not valid: `:999` raises SyntaxError.

This PR fixes the example to use the expected syntax for "numeric" datapoints (integers instead of atoms).