### PR TITLE
Fix 1.6 heredoc warning.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,8 +2,8 @@ defmodule Elixometer.Mixfile do
   use Mix.Project
 
   @description """
-  Elixometer is a light wrapper around exometer that defines and subscribes
-  metrics automatically to the configured reporter.
+  Elixometer is a light wrapper around exometer that defines and
+  subscribes metrics automatically to the configured reporter.
   """
 
   @project_url "https://github.com/pinterest/elixometer"


### PR DESCRIPTION
```
warning: outdented heredoc line. The contents inside the heredoc should be indented at the same level as the closing """. The following is forbidden:

    def text do
      """
    contents
      """
    end

Instead make sure the contents are indented as much as the heredoc closing:

    def text do
      """
      contents
      """
    end

The current heredoc line is indented too little
  /Users/asummers/Code/MyProject/deps/elixometer/mix.exs:51
```

Not sure what it was mad at, exactly, but this seems to fix it. 