### PR TITLE
Use Module for configuring formatter instead of function ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ config :elixometer, Elixometer.Updater,
   formatter: MyApp.Formatter
 ```
 
+A formatting function can also be used as the configuration entry:
+```elixir
+config :elixometer, Elixometer.Updater,
+  formatter: &MyApp.Formatter.format/2
+```
+
 Elixometer uses [`pobox`](https://github.com/ferd/pobox) to prevent overload.
 A maximum size of message buffer, defaulting to 1000, can be configured with:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can use an environment variable to set the `env`.
 config :elixometer, env: {:system, "ELIXOMETER_ENV"}
 ```
 
-By default, metrics are formatted using `Elixometer.Utils.name_to_exometer/2`.
+By default, metrics are formatted using `Elixometer.Utils.format/2`.
 This function takes care of composing metric names with prefix, environment and
 the metric type (e.g. `myapp_prefix.dev.timers.request_time`).
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ a single function, `format` as such:
 defmodule MyApp.Formatter do
   @behaviour Elixometer.Formatter
 
+  # If you prefer to hyphen-separate your strings, perhaps
   def format(metric_type, name) do
-    # do your formatting here
-    # return [String.t()]
+    String.split("#{metric_type}-#{name}", "-")
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,22 @@ config :elixometer, Elixometer.Updater,
   formatter: MyApp.Formatter
 ```
 
-A formatting function can also be used as the configuration entry:
+A formatting module implements the `Elixometer.Formatter` behaviour and implements
+a single function, `format` as such:
+
+```elixir
+defmodule MyApp.Formatter do
+  @behaviour Elixometer.Formatter
+
+  def format(metric_type, name) do
+    # do your formatting here
+    # return [String.t()]
+  end
+end
+```
+
+A formatting function can also be used as the configuration entry, provided it follows
+the same signature as a formatting module:
 ```elixir
 config :elixometer, Elixometer.Updater,
   formatter: &MyApp.Formatter.format/2

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -289,7 +289,7 @@ defmodule Elixometer do
   """
   @spec clear_counter(metric_name) :: :ok | {:error, any}
   def clear_counter(metric_name) when is_bitstring(metric_name) do
-    clear_counter(name_to_exometer(:counters, metric_name))
+    clear_counter(format(:counters, metric_name))
   end
 
   def clear_counter(metric_name) when is_list(metric_name) do

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -1,3 +1,4 @@
 defmodule Elixometer.Formatter do
-  @callback format(String.t(), String.t()) :: [String.t()]
+  @type metric_type :: :counter | :gauge | :histograms | :spirals | :timer
+  @callback format(metric_type, String.t()) :: [String.t()]
 end

--- a/lib/updater.ex
+++ b/lib/updater.ex
@@ -52,7 +52,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:histogram, name, delta, aggregate_seconds, truncate}, formatter) do
-    monitor = formatter.format(:histograms, name)
+    monitor = do_format(formatter, :histograms, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(
@@ -67,7 +67,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:spiral, name, delta, opts}, formatter) do
-    monitor = formatter.format(:spirals, name)
+    monitor = do_format(formatter, :spirals, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :spiral, opts)
@@ -77,7 +77,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:counter, name, delta, reset_seconds}, formatter) do
-    monitor = formatter.format(:counters, name)
+    monitor = do_format(formatter, :counters, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :counter, [])
@@ -93,7 +93,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:gauge, name, value}, formatter) do
-    monitor = formatter.format(:gauges, name)
+    monitor = do_format(formatter, :gauges, name)
 
     ensure_registered(monitor, fn ->
       :exometer.new(monitor, :gauge, [])
@@ -103,7 +103,7 @@ defmodule Elixometer.Updater do
   end
 
   def do_update({:timer, name, units, elapsed_us}, formatter) do
-    timer = formatter.format(:timers, name)
+    timer = do_format(formatter, :timers, name)
 
     ensure_registered(timer, fn ->
       :exometer.new(timer, :histogram, [])
@@ -122,5 +122,13 @@ defmodule Elixometer.Updater do
 
   defp activate_pobox do
     :pobox.active(:elixometer_pobox, fn msg, _ -> {{:ok, msg}, :nostate} end, :nostate)
+  end
+
+  defp do_format(formatter, metric, name) when is_function(formatter) do
+    formatter.(metric, name)
+  end
+
+  defp do_format(formatter, metric, name) do
+    formatter.format(metric, name)
   end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -2,14 +2,12 @@ defmodule Elixometer.Utils do
   @moduledoc false
   @behaviour Elixometer.Formatter
 
-  def format(metric_type, name), do: name_to_exometer(metric_type, name)
-
   # Name may already have been converted elsewhere.
-  def name_to_exometer(_metric_type, name) when is_list(name) do
+  def format(_metric_type, name) when is_list(name) do
     name
   end
 
-  def name_to_exometer(metric_type, name) when is_bitstring(name) do
+  def format(metric_type, name) when is_bitstring(name) do
     config = Application.get_all_env(:elixometer)
     prefix = config[:metric_prefix] || "elixometer"
 

--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -324,7 +324,7 @@ defmodule ElixometerTest do
   end
 
   test "name can be precomputed" do
-    name = Elixometer.Utils.name_to_exometer(:spirals, "precomputed_counter")
+    name = Elixometer.Utils.format(:spirals, "precomputed_counter")
     update_spiral(name, 123)
     wait_for_messages()
 
@@ -335,7 +335,7 @@ defmodule ElixometerTest do
     System.put_env("ELIXOMETER_ENV", "staging")
     Application.put_env(:elixometer, :env, {:system, "ELIXOMETER_ENV"})
 
-    name = Elixometer.Utils.name_to_exometer(:spirals, "precomputed_counter")
+    name = Elixometer.Utils.format(:spirals, "precomputed_counter")
     update_spiral(name, 123)
     wait_for_messages()
 
@@ -346,7 +346,7 @@ defmodule ElixometerTest do
     System.put_env("ELIXOMETER_ENV", "prod")
     Application.put_env(:elixometer, :env, {:system, "ELIXOMETER_ENV"})
 
-    name = Elixometer.Utils.name_to_exometer(:spirals, "precomputed_counter")
+    name = Elixometer.Utils.format(:spirals, "precomputed_counter")
     update_spiral(name, 123)
     wait_for_messages()
 
@@ -356,7 +356,7 @@ defmodule ElixometerTest do
   test "name can be precomputed with env config from environmental variable and env is not set" do
     Application.put_env(:elixometer, :env, {:system, "ELIXOMETER_MISSING_ENV"})
 
-    name = Elixometer.Utils.name_to_exometer(:spirals, "precomputed_counter_env_not_set")
+    name = Elixometer.Utils.format(:spirals, "precomputed_counter_env_not_set")
     update_spiral(name, 123)
     wait_for_messages()
 


### PR DESCRIPTION
Hi!
We've found that when attempting to build releases using Distillery, it barfs when trying to use a function ref as a config value.

This PR adds a behaviour so that anyone who wants to add a custom formatter module can do so safely. 