### PR TITLE
Require Elixir 1.5 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ branches:
     - "master"
 matrix:
   include:
-  - elixir: 1.3
-    otp_release: 18.2
-  - elixir: 1.4
-    otp_release: 19.2
   - elixir: 1.5
     otp_release: 20.2
   - elixir: 1.6
     otp_release: 20.2
   - elixir: 1.7
     otp_release: 21.0
-    env: CMD=coveralls.travis
   - elixir: 1.8
     otp_release: 21.0
     env: CMD=coveralls.travis

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Elixometer.Mixfile do
     [
       app: :elixometer,
       version: "1.3.0-dev",
-      elixir: ">= 1.3.0",
+      elixir: ">= 1.5.0",
       description: @description,
       source_url: @project_url,
       homepage_url: @project_url,


### PR DESCRIPTION
As we prepare for a new release, it's a good time to bump our minimum
required Elixir version. 1.5 is a good baseline as its what a number of
our dependencies now require.