### PR TITLE
feat: allow a bulk subscription, to get all metrics at once.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ config(:elixometer,
 
 The documentation on custom reporters in `exometer` is fairly difficult to find, and isn't exactly correct. It is still quite useful though, and can be found [here](https://github.com/Feuerlabs/exometer_core/blob/master/doc/exometer_report.md).
 
-
-Your best bet is to define a module that uses the `:exometer_report` behaviour, and use `@impl` on the functions that you add to adhere to that behaviour. 
+Your best bet is to define a module that uses the `:exometer_report` behaviour, and use `@impl` on the functions that you add to conform to that behaviour. 
 That will make sure that each function aligns with the behaviour, and that you haven't missed any required ones.
 
 There is one function that is not included as part of the erlang behaviour, but that you may want, which is `exometer_report_bulk/3`. 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ You can use an environment variable to set the `env`.
 config :elixometer, env: {:system, "ELIXOMETER_ENV"}
 ```
 
+Some reporters know how to handle multiple metrics reported at the same time. Or perhaps you want to write a custom reporter, and would like to receive all data points for a single metric all at once. 
+This can be achieved by adding the `report_bulk: true` option to the *reporter* configuration, and adding `bulk_subscribe: true` to the *elixometer* configuration. Like so:
+
+```elixir
+config :exometer_core,
+  report: [
+    reporters: [
+      {My.Custom.Reporter, [report_bulk: true]}
+    ]
+  ]
+
+config :elixometer,
+  # ...
+  bulk_subscribe: true
+```
+
 By default, metrics are formatted using `Elixometer.Utils.format/2`.
 This function takes care of composing metric names with prefix, environment and
 the metric type (e.g. `myapp_prefix.dev.timers.request_time`).
@@ -168,3 +184,14 @@ config(:elixometer,
   ...
   subscribe_options: [{:tag, :value1}])
 ```
+
+## Custom Reporters
+
+The documentation on custom reporters in `exometer` is fairly difficult to find, and isn't exactly correct. It is still quite useful though, and can be found [here](https://github.com/Feuerlabs/exometer_core/blob/master/doc/exometer_report.md).
+
+
+Your best bet is to define a module that uses the `:exometer_report` behaviour, and use `@impl` on the functions that you add to adhere to that behaviour. 
+That will make sure that each function aligns with the behaviour, and that you haven't missed any required ones.
+
+There is one function that is not included as part of the erlang behaviour, but that you may want, which is `exometer_report_bulk/3`. 
+*If and only if* you have defined that function in your reporter *and* you passed `report_bulk: true` as an option to the reporter, it will pass a list of datapoint/value pairs to your `exometer_report_bulk/3`.


### PR DESCRIPTION
If you want to avoid having to aggregate each different datapoint for each metric, you can use `report_bulk: true` in your reporters, like so: 

```
config :exometer_core,
  report: [
    reporters: [
      {ExometerTest.Reporter, [report_bulk: true]}
    ]
  ],
  update_frequency: :timer.seconds(5)
```

But in order for that to work, the subscription for each datapoint needs to be given at one time, as opposed to separate subscriptions. This allows that, by allowing the configuration option `bulk_subscribe: true`