### PR TITLE
Update the OTP releases used in the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ branches:
 matrix:
   include:
   - elixir: 1.5
-    otp_release: 20.2
+    otp_release: 19.3
   - elixir: 1.6
-    otp_release: 20.2
+    otp_release: 19.3
   - elixir: 1.7
-    otp_release: 21.0
+    otp_release: 21.1
   - elixir: 1.8
-    otp_release: 21.0
+    otp_release: 21.1
   - elixir: 1.9
-    otp_release: 21.0
+    otp_release: 21.1
     env: CMD=coveralls.travis
 env:
   - CMD=test


### PR DESCRIPTION
Use a more modern OTP 21 release and test older Elixir versions using
OTP 19.3.