### PR TITLE
Modernize GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,20 @@ on:
 
 jobs:
   build:
-    name: Elixir ${{ matrix.elixir-version }}
+    name: OTP ${{ matrix.otp-version }} / Elixir ${{ matrix.elixir-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        otp-version: [20.3, 21.3, 22.2]
         elixir-version: [1.5, 1.6, 1.7, 1.8, 1.9]
-    container:
-      image: elixir:${{ matrix.elixir-version }}
     env:
       MIX_ENV: test
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-elixir@v1.2.0
+        with:
+          otp-version: ${{ matrix.otp-version }}
+          elixir-version: ${{ matrix.elixir-version }}
       - name: Get dependency cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     name: OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         otp: [20.3, 22.2]
         elixir: [1.5, 1.6, 1.7, 1.8, 1.9]
@@ -40,13 +41,13 @@ jobs:
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
-      - name: Get dependency cache
+      - name: Set up dependency cache
         uses: actions/cache@v1
         with:
           path: deps/
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-deps-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-deps-
-      - name: Get build cache
+      - name: Set up build cache
         uses: actions/cache@v1
         with:
           path: _build/test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   format:
     name: Format
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,21 @@ on:
       - master
 
 jobs:
-  build:
+  format:
+    name: Format
+    env:
+      MIX_ENV: test
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-elixir@v1.2.0
+        with:
+          otp-version: 22.2
+          elixir-version: 1.9
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Check format
+        run: mix format --check-formatted
+  test:
     name: OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }}
     runs-on: ubuntu-latest
     strategy:
@@ -42,9 +56,6 @@ jobs:
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
-      - name: Check format
-        if: matrix.elixir == '1.9'
-        run: mix format --check-formatted
       - name: Compile
         run: |
           mix deps.compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp-version: [20.3, 22.2]
-        elixir-version: [1.5, 1.6, 1.7, 1.8, 1.9]
+        otp: [20.3, 22.2]
+        elixir: [1.5, 1.6, 1.7, 1.8, 1.9]
     env:
       MIX_ENV: test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp-version: [20.3, 21.3, 22.2]
+        otp-version: [20.3, 22.2]
         elixir-version: [1.5, 1.6, 1.7, 1.8, 1.9]
     env:
       MIX_ENV: test
@@ -25,18 +25,18 @@ jobs:
         with:
           otp-version: ${{ matrix.otp-version }}
           elixir-version: ${{ matrix.elixir-version }}
-      - name: Get dependency cache
-        uses: actions/cache@v1
-        with:
-          path: deps/
-          key: ${{ runner.os }}-deps-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-deps-
-      - name: Get build cache
-        uses: actions/cache@v1
-        with:
-          path: _build/test/
-          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-build-
+      # - name: Get dependency cache
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: deps/
+      #     key: ${{ runner.os }}-deps-${{ hashFiles('**/mix.lock') }}
+      #     restore-keys: ${{ runner.os }}-deps-
+      # - name: Get build cache
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: _build/test/
+      #     key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}
+      #     restore-keys: ${{ runner.os }}-build-
       - name: Install dependencies
         run: |
           mix local.rebar --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: OTP ${{ matrix.otp-version }} / Elixir ${{ matrix.elixir-version }}
+    name: OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,37 +23,37 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-elixir@v1.2.0
         with:
-          otp-version: ${{ matrix.otp-version }}
-          elixir-version: ${{ matrix.elixir-version }}
-      # - name: Get dependency cache
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: deps/
-      #     key: ${{ runner.os }}-deps-${{ hashFiles('**/mix.lock') }}
-      #     restore-keys: ${{ runner.os }}-deps-
-      # - name: Get build cache
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: _build/test/
-      #     key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}
-      #     restore-keys: ${{ runner.os }}-build-
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+      - name: Get dependency cache
+        uses: actions/cache@v1
+        with:
+          path: deps/
+          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-deps-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-deps-
+      - name: Get build cache
+        uses: actions/cache@v1
+        with:
+          path: _build/test/
+          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-build-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-build-
       - name: Install dependencies
         run: |
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
       - name: Check format
-        if: matrix.elixir-version == '1.9'
+        if: matrix.elixir == '1.9'
         run: mix format --check-formatted
       - name: Compile
         run: |
           mix deps.compile
           mix compile --force --warnings-as-errors
       - name: Run tests
-        if: matrix.elixir-version != '1.9'
+        if: matrix.elixir != '1.9'
         run: mix test
       - name: Run tests (with coverage)
-        if: matrix.elixir-version == '1.9'
+        if: matrix.elixir == '1.9'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mix coveralls.github


### PR DESCRIPTION
The latest version (v1.2.0) now supports the full range of Elixir/OTP
versions going back to OTP 17 and Elixir 1.0.