### PR TITLE
Add Elixir version 1.11 to the testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-elixir@v1
         with:
           otp-version: 22.2
-          elixir-version: '1.10'
+          elixir-version: '1.11'
       - name: Install dependencies
         run: mix deps.get
       - name: Check format
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         otp: [22.2]
-        elixir: [1.5, 1.6, 1.7, 1.8, 1.9, '1.10']
+        elixir: [1.5, 1.6, 1.7, 1.8, 1.9, '1.10', '1.11']
     env:
       MIX_ENV: test
     steps:
@@ -61,10 +61,10 @@ jobs:
           mix deps.compile
           mix compile --force --warnings-as-errors
       - name: Run tests
-        if: matrix.elixir != '1.10'
+        if: matrix.elixir != '1.11'
         run: mix test
       - name: Run tests (with coverage)
-        if: matrix.elixir == '1.10'
+        if: matrix.elixir == '1.11'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mix coveralls.github

--- a/lib/elixometer.ex
+++ b/lib/elixometer.ex
@@ -475,7 +475,7 @@ defmodule Elixometer do
       :error ->
         info
         |> Keyword.fetch!(:value)
-        |> Keyword.keys()
+        |> Enum.map(fn {k, _v} -> k end)
     end
   end
 end


### PR DESCRIPTION
Elixir 1.11 now enforces keys to be atoms in Keyword.keys/1, so also
update a place where we were making that assumption.