### PR TITLE
Remove the "Elixir 1.5" test tag support

### DIFF
--- a/test/elixometer_test.exs
+++ b/test/elixometer_test.exs
@@ -266,7 +266,6 @@ defmodule ElixometerTest do
     assert ns > 1_000_000
   end
 
-  @tag elixir: 1.5
   test "a bodyless timer defined in a module raises a RuntimeError" do
     on_exit(fn ->
       :code.delete(BodylessModule)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,1 @@
-# Exclude Elixir 1.5-tagged tests when running on earlier versions.
-if Version.compare(System.version(), "1.5.0-rc") == :lt do
-  ExUnit.configure(exclude: [elixir: 1.5])
-end
-
 ExUnit.start()


### PR DESCRIPTION
We already require Elixir 1.5 or later so this version check is no
longer needed.